### PR TITLE
[WIP] Forward synctex

### DIFF
--- a/EDITOR-PROTOCOL.md
+++ b/EDITOR-PROTOCOL.md
@@ -90,6 +90,12 @@ Move TeXpresso to the specified screen coordinates. For GUI editors, this can be
 
 Asking the window manager to keep TeXpresso window above the others, or not. This can be convenient to keep a TeXpresso window floating on top of the editor. (`t` and `nil` are the closest approximation of "true" and "false" in emacs-sexp).
 
+```scheme
+(synctex-forward "path" line)
+```
+
+Try to scroll the UI to the contents defined in TeX file at "path" and line. The path can be absolute or relative to the root document.
+
 ## Messages (texpresso -> editor)
 
 ### Synchronizing output messages and log file
@@ -124,6 +130,7 @@ Sample script:
 ```
 
 SyncTeX backward synchronisation: the user clicked on text produced by LaTeX sources at path:line. The action is usually to open this file in the editor and jumps to this line.
+The path is relative to the root document.
 
 
 ### VFS reset

--- a/emacs/texpresso.el
+++ b/emacs/texpresso.el
@@ -160,7 +160,8 @@ Character counts are converted to byte offsets using `texpresso--before-change'.
                       (process-get texpresso--process 'marker)))
           (texpresso--send 'open (buffer-file-name)
                            (buffer-substring-no-properties
-                            (point-min) (point-max))))))))
+                            (point-min) (point-max))))
+        (texpresso--send 'synctex-forward (buffer-file-name) (line-number-at-pos nil t))))))
 
 (defun texpresso--stderr-filter (process text)
   "Save debug TEXT from TeXpresso PROCESS in *texpresso-stderr* buffer.

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,11 +13,11 @@ $(BUILD)/texpresso: $(DIR)/driver.o $(DIR)/main.o $(DIR)/logo.o $(DIR_OBJECTS) $
 	$(CC) -o $@ $^ $(LIBS)
 
 texpresso-dev: $(BUILD)/texpresso-dev
-$(BUILD)/texpresso-dev: $(DIR)/driver.o $(DIR)/loader.o $(DIR)/logo.o $(BUILD)/texpresso.so
+$(BUILD)/texpresso-dev: $(DIR)/driver.o $(DIR)/loader.o $(DIR)/logo.o | $(BUILD)/texpresso-dev.so
 	$(CC) -o $@ $^ $(LIBS)
 
-texpresso.so: $(BUILD)/texpresso.so
-$(BUILD)/texpresso.so: $(DIR)/main.o $(DIR_OBJECTS) $(DIR)/libmydvi.a
+texpresso-dev.so: $(BUILD)/texpresso-dev.so
+$(BUILD)/texpresso-dev.so: $(DIR)/main.o $(DIR_OBJECTS) $(DIR)/libmydvi.a
 	$(MAKE) -C dvi
 	$(CC) -ldl -shared -o $@ $^ $(LIBS)
 	killall -SIGUSR1 texpresso-dev || true

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-OBJECTS=sprotocol.o state.o fs.o incdvi.o myabort.o renderer.o engine_tex.o engine_pdf.o engine_dvi.o synctex.o sexp_parser.o
+OBJECTS=sprotocol.o state.o fs.o incdvi.o myabort.o renderer.o engine_tex.o engine_pdf.o engine_dvi.o synctex.o sexp_parser.o editor.o
 
 BUILD=../build
 DIR=$(BUILD)/objects

--- a/src/driver.c
+++ b/src/driver.c
@@ -123,9 +123,33 @@ int main(int argc, const char **argv)
   }
   fprintf(stderr, "[info] executable path: %s\n", exe_path);
 
+  const char *doc_arg = NULL;
+  enum editor_protocol protocol = EDITOR_SEXP;
+
+  switch (argc)
+  {
+    case 2:
+      // texpresso foo.tex
+      doc_arg = argv[1];
+      break;
+
+    case 3:
+      // texpresso -json foo.tex
+      if (strcmp(argv[1], "-json") == 0)
+      {
+        doc_arg = argv[2];
+        protocol = EDITOR_JSON;
+        break;
+      }
+
+    default:
+      fprintf(stderr, "Usage: texpresso [-json] root_file.tex\n");
+      exit(1);
+  }
+
   // Move to TeX document directory
   char doc_path[PATH_MAX];
-  if (!realpath(argv[1], doc_path))
+  if (!realpath(doc_arg, doc_path))
   {
     perror("finding document path");
     abort();
@@ -184,6 +208,7 @@ int main(int argc, const char **argv)
 
   struct persistent_state pstate = {
       .initial = {0,},
+      .protocol = protocol,
       .window = window,
       .renderer = renderer,
       .ctx = ctx,

--- a/src/driver.h
+++ b/src/driver.h
@@ -48,8 +48,15 @@ struct initial_state
   fz_display_list *display_list;
 };
 
+enum editor_protocol
+{
+  EDITOR_SEXP,
+  EDITOR_JSON,
+};
+
 struct persistent_state {
   struct initial_state initial;
+  enum editor_protocol protocol;
   Uint32 custom_event;
 
   uint32_t theme_bg, theme_fg;

--- a/src/dvi/dvi_fonttable.c
+++ b/src/dvi/dvi_fonttable.c
@@ -51,7 +51,7 @@ dvi_fontdef *dvi_fonttable_get(fz_context *ctx, dvi_fonttable *ft, int f)
 {
   if (f < 0 || f > 9999)
   {
-    printf("dvi_fonttable_get(_, %d)\n", f);
+    fprintf(stderr, "dvi_fonttable_get(_, %d)\n", f);
     abort();
   }
   if (f >= ft->capacity)

--- a/src/dvi/tex_fontmap.c
+++ b/src/dvi/tex_fontmap.c
@@ -262,10 +262,10 @@ int max_poschain = 0, max_negchain = 0, lookup_count = 0, lookup_probe = 0;
 
 static void print_chain(void)
 {
-  printf("tex_fontmap: max_pos_chain: %d\n", max_poschain);
-  printf("tex_fontmap: max_neg_chain: %d\n", max_negchain);
-  printf("tex_fontmap: lookup_count: %d\n", lookup_count);
-  printf("tex_fontmap: average_chain: %f\n", (double)lookup_probe / (double)lookup_count);
+  fprintf(stderr, "tex_fontmap: max_pos_chain: %d\n", max_poschain);
+  fprintf(stderr, "tex_fontmap: max_neg_chain: %d\n", max_negchain);
+  fprintf(stderr, "tex_fontmap: lookup_count: %d\n", lookup_count);
+  fprintf(stderr, "tex_fontmap: average_chain: %f\n", (double)lookup_probe / (double)lookup_count);
 }
 #endif
 

--- a/src/dvi/tex_tfm.c
+++ b/src/dvi/tex_tfm.c
@@ -246,18 +246,18 @@ tex_tfm *tex_tfm_load(fz_context *ctx, fz_stream *stm)
     if (p - buf != 24) abort();
 
 #ifdef DEBUG_TFM
-    printf("lf = %4u   %% length of the entire file, in words\n",        lf);
-    printf("lh = %4u   %% length of the header data, in words\n",        lh);
-    printf("bc = %4u   %% smallest character code in the font\n",        bc);
-    printf("ec = %4u   %% largest character code in the font\n",         ec);
-    printf("nw = %4u   %% number of words in the width table\n",         nw);
-    printf("nh = %4u   %% number of words in the height table\n",        nh);
-    printf("nd = %4u   %% number of words in the depth table\n",         nd);
-    printf("ni = %4u   %% number of words in the italic correction table\n",   ni);
-    printf("nl = %4u   %% number of words in the lig/kern table\n",        nl);
-    printf("nk = %4u   %% number of words in the kern table\n",          nk);
-    printf("ne = %4u   %% number of words in the extensible character table\n",  ne);
-    printf("np = %4u   %% number of font parameter words\n",           np);
+    fprintf(stderr, "lf = %4u   %% length of the entire file, in words\n",        lf);
+    fprintf(stderr, "lh = %4u   %% length of the header data, in words\n",        lh);
+    fprintf(stderr, "bc = %4u   %% smallest character code in the font\n",        bc);
+    fprintf(stderr, "ec = %4u   %% largest character code in the font\n",         ec);
+    fprintf(stderr, "nw = %4u   %% number of words in the width table\n",         nw);
+    fprintf(stderr, "nh = %4u   %% number of words in the height table\n",        nh);
+    fprintf(stderr, "nd = %4u   %% number of words in the depth table\n",         nd);
+    fprintf(stderr, "ni = %4u   %% number of words in the italic correction table\n",   ni);
+    fprintf(stderr, "nl = %4u   %% number of words in the lig/kern table\n",        nl);
+    fprintf(stderr, "nk = %4u   %% number of words in the kern table\n",          nk);
+    fprintf(stderr, "ne = %4u   %% number of words in the extensible character table\n",  ne);
+    fprintf(stderr, "np = %4u   %% number of font parameter words\n",           np);
 #endif
 
     int expected_len = 6+lh+(ec - bc +1)+nw+nh+nd+ni+nl+nk+ne+np;

--- a/src/editor.c
+++ b/src/editor.c
@@ -1,0 +1,226 @@
+#include "editor.h"
+
+// Processing input
+
+static void parse_color(fz_context *ctx, vstack *stack, float out[3], val col)
+{
+  out[0] = val_number(ctx, val_array_get(ctx, stack, col, 0));
+  out[1] = val_number(ctx, val_array_get(ctx, stack, col, 1));
+  out[2] = val_number(ctx, val_array_get(ctx, stack, col, 2));
+}
+
+static bool lisp_truth_value(fz_context *ctx, vstack *t, val v)
+{
+  return !(val_is_name(v) && strcmp(val_as_name(ctx, t, v), "nil") == 0);
+}
+
+bool editor_parse(fz_context *ctx,
+                  vstack *stack,
+                  val command,
+                  struct editor_command *out)
+{
+  if (!val_is_array(command))
+  {
+    fprintf(stderr, "[command] invalid (not an array)");
+    return 0;
+  }
+
+  int len = val_array_length(ctx, stack, command);
+  if (len == 0)
+  {
+    fprintf(stderr, "[command] invalid (empty array)");
+    return 0;
+  }
+
+  const char *verb =
+      val_as_name(ctx, stack, val_array_get(ctx, stack, command, 0));
+
+  if (!verb)
+  {
+    fprintf(stderr, "[command] invalid (no verb)");
+    return 0;
+  }
+
+  if (strcmp(verb, "open") == 0)
+  {
+    if (len != 3)
+      goto arity;
+    val path = val_array_get(ctx, stack, command, 1);
+    val data = val_array_get(ctx, stack, command, 2);
+    if (!val_is_string(path) || !val_is_string(data))
+      goto arguments;
+    *out = (struct editor_command){
+        .tag = EDIT_OPEN,
+        .open =
+            {
+                .path = val_string(ctx, stack, path),
+                .data = val_string(ctx, stack, data),
+                .length = val_string_length(ctx, stack, data),
+            },
+
+    };
+  }
+  else if (strcmp(verb, "close") == 0)
+  {
+    if (len != 2) goto arity;
+    val path = val_array_get(ctx, stack, command, 1);
+    if (!val_is_string(path))
+      goto arguments;
+    *out = (struct editor_command){
+        .tag = EDIT_CLOSE,
+        .close =
+            {
+                .path = val_string(ctx, stack, path),
+            },
+
+    };
+  }
+  else if (strcmp(verb, "change") == 0)
+  {
+    if (len != 5) goto arity;
+    val path = val_array_get(ctx, stack, command, 1);
+    val offset = val_array_get(ctx, stack, command, 2);
+    val length = val_array_get(ctx, stack, command, 3);
+    val data = val_array_get(ctx, stack, command, 4);
+    if (!val_is_string(path) ||
+        !val_is_number(offset) ||
+        !val_is_number(length) ||
+        !val_is_string(data))
+      goto arguments;
+    *out = (struct editor_command){
+        .tag = EDIT_CHANGE,
+        .change =
+            {
+                .path = val_string(ctx, stack, path),
+                .offset = val_number(ctx, offset),
+                .remove_length = val_number(ctx, length),
+                .data = val_string(ctx, stack, data),
+                .insert_length = val_string_length(ctx, stack, data),
+            },
+    };
+  }
+  else if (strcmp(verb, "theme") == 0)
+  {
+    if (len != 3) goto arity;
+    val bg = val_array_get(ctx, stack, command, 1);
+    val fg = val_array_get(ctx, stack, command, 2);
+    out->tag = EDIT_THEME;
+    parse_color(ctx, stack, out->theme.bg, bg);
+    parse_color(ctx, stack, out->theme.fg, fg);
+  }
+  else if (strcmp(verb, "previous-page") == 0)
+  {
+    *out =
+        (struct editor_command){.tag = EDIT_PREVIOUS_PAGE, .previous_page = {}};
+  }
+  else if (strcmp(verb, "next-page") == 0)
+  {
+    *out = (struct editor_command){.tag = EDIT_NEXT_PAGE, .next_page = {}};
+  }
+  else if (strcmp(verb, "move-window") == 0)
+  {
+    if (len != 5) goto arity;
+    *out = (struct editor_command){
+        .tag = EDIT_MOVE_WINDOW,
+        .move_window = {
+            .x = val_number(ctx, val_array_get(ctx, stack, command, 1)),
+            .y = val_number(ctx, val_array_get(ctx, stack, command, 2)),
+            .w = val_number(ctx, val_array_get(ctx, stack, command, 3)),
+            .h = val_number(ctx, val_array_get(ctx, stack, command, 4)),
+        }};
+  }
+  else if (strcmp(verb, "stay-on-top") == 0)
+  {
+    if (len != 2)
+      goto arity;
+    bool status =
+        lisp_truth_value(ctx, stack, val_array_get(ctx, stack, command, 1));
+    *out = (struct editor_command){.tag = EDIT_STAY_ON_TOP,
+                                   .stay_on_top = {.status = status}};
+  }
+  else
+  {
+    fprintf(stderr, "[command] unknown verb: %s\n", verb);
+    return 0;
+  }
+  return 1;
+
+arity:
+  fprintf(stderr, "[command] %s: invalid arity\n", verb);
+  return 0;
+
+arguments:
+  fprintf(stderr, "[command] %s: invalid arguments\n", verb);
+  return 0;
+}
+
+// Sending output
+
+static void output_sexp_string(FILE *f, const char *ptr, int len)
+{
+  for (const char *lim = ptr + len; ptr < lim; ptr++)
+  {
+    char c = *ptr;
+    switch (c)
+    {
+      case '\t':
+        putc_unlocked('\\', f);
+        c = 't';
+        break;
+      case '\r':
+        putc_unlocked('\\', f);
+        c = 'r';
+        break;
+      case '\n':
+        c = 'n';
+      case '"':
+      case '\\':
+        putc_unlocked('\\', f);
+    }
+    putc_unlocked(c, f);
+  }
+}
+
+static const char *editor_info_buffer(enum EDITOR_INFO_BUFFER name)
+{
+  switch (name)
+  {
+    case BUF_LOG:
+      return "log";
+
+    case BUF_OUT:
+      return "out";
+  }
+}
+
+void editor_append(enum EDITOR_INFO_BUFFER name,
+                   int pos,
+                   const char *data,
+                   int data_len)
+{
+  fprintf(stdout, "(append %s %d \"", editor_info_buffer(name), pos);
+  output_sexp_string(stdout, data, data_len);
+  fprintf(stdout, "\")\n");
+}
+
+void editor_truncate(enum EDITOR_INFO_BUFFER name, int length)
+{
+  fprintf(stdout, "(truncate %s %d)\n", editor_info_buffer(name), length);
+}
+
+void editor_flush(void)
+{
+  puts("(flush)\n");
+}
+
+void editor_synctex(const char *path, int path_len, int line, int column)
+{
+  fprintf(stdout, "(synctex \"");
+  output_sexp_string(stdout, (const void *)path, path_len);
+  fprintf(stdout, "\" %d %d)\n", line, column);
+}
+
+void editor_reset_sync(void)
+{
+  puts("(reset-sync)\n");
+}

--- a/src/editor.c
+++ b/src/editor.c
@@ -149,6 +149,23 @@ bool editor_parse(fz_context *ctx,
     *out = (struct editor_command){.tag = EDIT_STAY_ON_TOP,
                                    .stay_on_top = {.status = status}};
   }
+  else if (strcmp(verb, "synctex-forward") == 0)
+  {
+    if (len != 3)
+      goto arity;
+    val path = val_array_get(ctx, stack, command, 1);
+    val line = val_array_get(ctx, stack, command, 2);
+    if (!val_is_string(path) || !val_is_number(line))
+      goto arguments;
+    *out = (struct editor_command){
+        .tag = EDIT_SYNCTEX_FORWARD,
+        .synctex_forward =
+            {
+                .path = val_string(ctx, stack, path),
+                .line = val_number(ctx, line),
+            },
+    };
+  }
   else
   {
     fprintf(stderr, "[command] unknown verb: %s\n", verb);

--- a/src/editor.h
+++ b/src/editor.h
@@ -18,6 +18,7 @@ enum EDITOR_COMMAND
   EDIT_NEXT_PAGE,
   EDIT_MOVE_WINDOW,
   EDIT_STAY_ON_TOP,
+  EDIT_SYNCTEX_FORWARD,
 };
 
 struct editor_command {
@@ -55,6 +56,11 @@ struct editor_command {
     struct {
       bool status;
     } stay_on_top;
+
+    struct {
+      const char *path;
+      int line;
+    } synctex_forward;
   };
 };
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -1,0 +1,81 @@
+#ifndef EDITOR_H_
+#define EDITOR_H_
+
+#include "vstack.h"
+
+// Receiving commands
+
+enum EDITOR_COMMAND
+{
+  EDIT_OPEN,
+  EDIT_CLOSE,
+  EDIT_CHANGE,
+  EDIT_THEME,
+  EDIT_PREVIOUS_PAGE,
+  EDIT_NEXT_PAGE,
+  EDIT_MOVE_WINDOW,
+  EDIT_STAY_ON_TOP,
+};
+
+struct editor_command {
+  enum EDITOR_COMMAND tag;
+  union {
+    struct {
+      const char *path;
+      const char *data;
+      int length;
+    } open;
+
+    struct {
+      const char *path;
+    } close;
+
+    struct {
+      const char *path, *data;
+      int offset, remove_length, insert_length;
+    } change;
+
+    struct {
+      float bg[3], fg[3];
+    } theme;
+
+    struct {
+    } previous_page;
+
+    struct {
+    } next_page;
+
+    struct {
+      float x, y, w, h;
+    } move_window;
+
+    struct {
+      bool status;
+    } stay_on_top;
+  };
+};
+
+bool editor_parse(fz_context *ctx,
+                  vstack *stack,
+                  val command,
+                  struct editor_command *out);
+
+// Sending message
+
+enum EDITOR_INFO_BUFFER
+{
+  BUF_OUT, // TeX process stdout
+  BUF_LOG, // TeX output log file
+};
+
+void editor_append(enum EDITOR_INFO_BUFFER name,
+                   int pos,
+                   const char *data,
+                   int data_len);
+
+void editor_truncate(enum EDITOR_INFO_BUFFER name, int length);
+void editor_flush(void);
+void editor_synctex(const char *path, int path_len, int line, int column);
+void editor_reset_sync(void);
+
+#endif  // EDITOR_H_

--- a/src/editor.h
+++ b/src/editor.h
@@ -1,7 +1,10 @@
 #ifndef EDITOR_H_
 #define EDITOR_H_
 
+#include "driver.h"
 #include "vstack.h"
+
+void editor_set_protocol(enum editor_protocol protocol);
 
 // Receiving commands
 

--- a/src/main.c
+++ b/src/main.c
@@ -989,11 +989,21 @@ bool texpresso_main(struct persistent_state *ps)
         }
 
         // TODO scroll to point
-        // fz_point p = fz_make_point(x, y);
-        // fz_point pt = txp_renderer_document_to_screen(ps->ctx, ui->doc_renderer, p);
-        // float f = 1 / send(scale_factor, ui->eng);
-        // txp_renderer_page_position
-        // synctex_scan(ctx, stx, buf, ui->page, f * pt.x, f * pt.y);
+        float f = send(scale_factor, ui->eng);
+        fz_point p = fz_make_point(f * x, f * y);
+        fz_point pt = txp_renderer_document_to_screen(ps->ctx, ui->doc_renderer, p);
+        fprintf(stderr, "[synctex forward] position on screen: (%.02f, %.02f)\n",
+                pt.x, pt.y);
+        int w, h;
+        txp_renderer_screen_size(ps->ctx, ui->doc_renderer, &w, &h);
+        float margin = h / 5.0;
+
+        txp_renderer_config *config =
+            txp_renderer_get_config(ps->ctx, ui->doc_renderer);
+        if (pt.y < margin)
+          config->pan.y += - pt.y + margin;
+        else if (pt.y >= h - margin)
+          config->pan.y += h - pt.y - margin;
       }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -996,16 +996,17 @@ bool texpresso_main(struct persistent_state *ps)
                 pt.x, pt.y);
         int w, h;
         txp_renderer_screen_size(ps->ctx, ui->doc_renderer, &w, &h);
-        float margin = h / 5.0;
+        float margin_lo = h / 4.0;
+        float margin_hi = h / 3.0;
 
         txp_renderer_config *config =
             txp_renderer_get_config(ps->ctx, ui->doc_renderer);
 
         float delta = 0.0;
-        if (pt.y < margin)
-          delta = - pt.y + margin;
-        else if (pt.y >= h - margin)
-          delta = h - pt.y - margin;
+        if (pt.y < margin_lo)
+          delta = - pt.y + margin_hi;
+        else if (pt.y >= h - margin_lo)
+          delta = h - pt.y - margin_hi;
         fprintf(stderr, "[synctex forward] pan.y = %.02f + %.02f = %.02f\n",
                 config->pan.y, delta, config->pan.y + delta);
         config->pan.y += delta;

--- a/src/main.c
+++ b/src/main.c
@@ -791,6 +791,7 @@ static void interpret_command(struct persistent_state *ps,
 
 bool texpresso_main(struct persistent_state *ps)
 {
+  editor_set_protocol(ps->protocol);
   pstate = ps;
 
   ui_state raw_ui, *ui = &raw_ui;

--- a/src/main.c
+++ b/src/main.c
@@ -979,7 +979,7 @@ bool texpresso_main(struct persistent_state *ps)
       if (synctex_has_target(stx) &&
           synctex_find_target(ps->ctx, stx, buf, &page, &x, &y))
       {
-        fprintf(stderr, "SyncTeX forward sync: hit page %d, coordinates (%d, %d)\n",
+        fprintf(stderr, "[synctex forward] sync: hit page %d, coordinates (%d, %d)\n",
                 page, x, y);
 
         if (page != ui->page)
@@ -988,7 +988,7 @@ bool texpresso_main(struct persistent_state *ps)
           display_page(ps, ui);
         }
 
-        // TODO scroll to point
+        // FIXME: Scroll to point
         float f = send(scale_factor, ui->eng);
         fz_point p = fz_make_point(f * x, f * y);
         fz_point pt = txp_renderer_document_to_screen(ps->ctx, ui->doc_renderer, p);
@@ -1000,10 +1000,16 @@ bool texpresso_main(struct persistent_state *ps)
 
         txp_renderer_config *config =
             txp_renderer_get_config(ps->ctx, ui->doc_renderer);
+
+        float delta = 0.0;
         if (pt.y < margin)
-          config->pan.y += - pt.y + margin;
+          delta = - pt.y + margin;
         else if (pt.y >= h - margin)
-          config->pan.y += h - pt.y - margin;
+          delta = h - pt.y - margin;
+        fprintf(stderr, "[synctex forward] pan.y = %.02f + %.02f = %.02f\n",
+                config->pan.y, delta, config->pan.y + delta);
+        config->pan.y += delta;
+        synctex_set_target(stx, NULL, 0);
       }
     }
 

--- a/src/myabort.c
+++ b/src/myabort.c
@@ -36,7 +36,7 @@ static void print_backtrace(void)
   char **strings;
 
   nptrs = backtrace(buffer, BT_BUF_SIZE);
-  printf("backtrace() returned %d addresses\n", nptrs);
+  fprintf(stderr, "backtrace() returned %d addresses\n", nptrs);
 
   /* The call backtrace_symbols_fd(buffer, nptrs, STDOUT_FILENO)
      would produce similar output to the following: */
@@ -48,7 +48,7 @@ static void print_backtrace(void)
   }
 
   for (int j = 0; j < nptrs; j++)
-    printf("%s\n", strings[j]);
+    fprintf(stderr, "%s\n", strings[j]);
 
   free(strings);
 }
@@ -57,9 +57,9 @@ static void print_backtrace(void)
 void myabort_(const char *file, int line, const char *msg, uint32_t code)
 {
   if (code == 42424242)
-    printf("Aborting from %s:%d (%s)\n", file, line, msg);
+    fprintf(stderr, "Aborting from %s:%d (%s)\n", file, line, msg);
   else
-    printf("Aborting from %s:%d (%s: %08X, '%c%c%c%c')\n", file, line, msg, code, code & 0xFF, (code >> 8) & 0XFF, (code >> 16) & 0xFF, (code >> 24) & 0xFF);
+    fprintf(stderr, "Aborting from %s:%d (%s: %08X, '%c%c%c%c')\n", file, line, msg, code, code & 0xFF, (code >> 8) & 0XFF, (code >> 16) & 0xFF, (code >> 24) & 0xFF);
 
   print_backtrace();
   abort();

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -961,3 +961,9 @@ fz_point txp_renderer_document_to_screen(fz_context *ctx, txp_renderer *self, fz
     return fz_make_point(0, 0);
   return fz_make_point(pt.x * scale + translate.x, pt.y * scale + translate.y);
 }
+
+void txp_renderer_screen_size(fz_context *ctx, txp_renderer *self, int *w, int *h)
+{
+  *w = self->output_w;
+  *h = self->output_h;
+}

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -952,3 +952,12 @@ fz_point txp_renderer_screen_to_document(fz_context *ctx, txp_renderer *self, fz
     return fz_make_point(0, 0);
   return fz_make_point((pt.x - translate.x) / scale, (pt.y - translate.y) / scale);
 }
+
+fz_point txp_renderer_document_to_screen(fz_context *ctx, txp_renderer *self, fz_point pt)
+{
+  fz_point translate;
+  float scale;
+  if (!txp_renderer_page_position(ctx, self, NULL, &translate, &scale))
+    return fz_make_point(0, 0);
+  return fz_make_point(pt.x * scale + translate.x, pt.y * scale + translate.y);
+}

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -61,6 +61,7 @@ bool txp_renderer_start_selection(fz_context *ctx, txp_renderer *self, fz_point 
 bool txp_renderer_drag_selection(fz_context *ctx, txp_renderer *self, fz_point pt);
 bool txp_renderer_select_word(fz_context *ctx, txp_renderer *self, fz_point pt);
 bool txp_renderer_select_char(fz_context *ctx, txp_renderer *self, fz_point pt);
+void txp_renderer_screen_size(fz_context *ctx, txp_renderer *self, int *w, int *h);
 fz_point txp_renderer_screen_to_document(fz_context *ctx, txp_renderer *self, fz_point pt);
 fz_point txp_renderer_document_to_screen(fz_context *ctx, txp_renderer *self, fz_point pt);
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -62,5 +62,6 @@ bool txp_renderer_drag_selection(fz_context *ctx, txp_renderer *self, fz_point p
 bool txp_renderer_select_word(fz_context *ctx, txp_renderer *self, fz_point pt);
 bool txp_renderer_select_char(fz_context *ctx, txp_renderer *self, fz_point pt);
 fz_point txp_renderer_screen_to_document(fz_context *ctx, txp_renderer *self, fz_point pt);
+fz_point txp_renderer_document_to_screen(fz_context *ctx, txp_renderer *self, fz_point pt);
 
 #endif /*!_RENDERER_H_*/

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -691,7 +691,7 @@ int synctex_find_target(fz_context *ctx, synctex_t *stx, fz_buffer *buf,
       if (plen == len && strncmp(stx->target_path, fname, len) == 0)
       {
         stx->target_tag = stx->target_inp_len;
-        fprintf(stderr, "[synctex] Target tag index: %d\n", stx->target_tag);
+        fprintf(stderr, "[synctex forward] target tag: %d\n", stx->target_tag);
         int page = 0, offset = stx->inputs.ptr[stx->target_tag];
         while (page < synctex_page_count(stx) &&
                stx->pages.ptr[page * 2 + 1] < offset)
@@ -720,7 +720,7 @@ int synctex_find_target(fz_context *ctx, synctex_t *stx, fz_buffer *buf,
       if (y) *y = stx->target_y;
       return 1;
     }
-    fprintf(stderr, "[synctex] Scanned page %d for target\n", stx->target_page_cand);
+    fprintf(stderr, "[synctex forward] scanned page %d\n", stx->target_page_cand);
     stx->target_page_cand += 1;
   }
 

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -658,6 +658,7 @@ int synctex_find_target(fz_context *ctx, synctex_t *stx, fz_buffer *buf,
                stx->pages.ptr[page * 2 + 1] < offset)
           page += 1;
         stx->target_page_cand = page;
+        stx->target_page = -1;
         break;
       }
       stx->target_inp_len++;

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -400,12 +400,12 @@ parse_line(const uint8_t *ptr, struct record *r)
 
     case 'g':
       r->kind = STEX_GLUE;
-      has_link = has_point = has_width = 1;
+      has_link = has_point = 1;
       break;
 
     case '$':
       r->kind = STEX_MATH;
-      has_link = has_point = has_width = 1;
+      has_link = has_point = 1;
       break;
 
     case '(':

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include "synctex.h"
 #include "editor.h"
+#include "myabort.h"
 
 struct offset_buffer
 {
@@ -249,7 +250,7 @@ int synctex_input_count(synctex_t *stx)
 void synctex_page_offset(fz_context *ctx, synctex_t *stx, unsigned index, int *bop, int *eop)
 {
   if (index * 2 + 1 >= stx->pages.len)
-    abort();
+    myabort();
 
   *bop = stx->pages.ptr[2 * index + 0];
   *eop = stx->pages.ptr[2 * index + 1];
@@ -258,7 +259,7 @@ void synctex_page_offset(fz_context *ctx, synctex_t *stx, unsigned index, int *b
 int synctex_input_offset(fz_context *ctx, synctex_t *stx, unsigned index)
 {
   if (index >= stx->inputs.len)
-    abort();
+    myabort();
 
   return stx->inputs.ptr[index];
 }
@@ -380,7 +381,7 @@ static const uint8_t *
 parse_line(const uint8_t *ptr, struct record *r)
 {
   if (!ptr) return NULL;
-  if (ptr[-1] != '\n') abort();
+  if (ptr[-1] != '\n') myabort();
 
   int has_link = 0, has_point = 0, has_size = 0, has_width = 0;
 
@@ -437,18 +438,18 @@ parse_line(const uint8_t *ptr, struct record *r)
   ptr += 1;
 
   if (has_link && !parse_link(&ptr, &r->link))
-    abort();
+    myabort();
 
   if (has_point && ((*ptr++ != ':') || !parse_point(&ptr, &r->point)))
-    abort();
+    myabort();
 
   if (has_size && ((*ptr++ != ':') || !parse_size(&ptr, &r->size)))
-    abort();
+    myabort();
 
   if (has_width)
   {
     if (*ptr++ != ':')
-      abort();
+      myabort();
     ptr = string_parse_int(ptr, &r->size.width);
   }
 

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -685,7 +685,8 @@ rev_parse_page(synctex_t *stx, fz_buffer *buf, const uint8_t *ptr)
         stx->target_x = r.point.x;
         stx->target_y = r.point.y;
       }
-      return (r.link.line >= line);
+      if (r.link.line >= line)
+        return 1;
     }
   }
   return 0;

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -548,10 +548,10 @@ static int get_input(fz_buffer *buf,
   while (*filename != ':')
     filename++;
   filename++;
+  *name = filename;
   const char *fend = filename;
   while (*fend != '\n')
     fend++;
-  *name = filename;
   return (fend - filename);
 }
 
@@ -606,7 +606,7 @@ void synctex_set_target(synctex_t *stx, const char *path, int line)
   stx->target_path[length] = 0;
   stx->target_tag = -1;
   stx->target_line = line;
-  stx->target_inp_len = -1;
+  stx->target_inp_len = 0;
   stx->target_page_cand = 0;
 }
 

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -22,9 +22,10 @@
  * IN THE SOFTWARE.
  */
 
-#include "synctex.h"
 #include <math.h>
 #include <string.h>
+#include "synctex.h"
+#include "editor.h"
 
 struct offset_buffer
 {
@@ -517,31 +518,6 @@ parse_tree(synctex_t *stx, fz_buffer *buf, const uint8_t *ptr, int x, int y, str
   }
 }
 
-static void output_sexp_string(FILE *f, const char *ptr, int len)
-{
-  for (const char *lim = ptr + len; ptr < lim; ptr++)
-  {
-    char c = *ptr;
-    switch (c)
-    {
-      case '\t':
-        putc_unlocked('\\', f);
-        c = 't';
-        break;
-      case '\r':
-        putc_unlocked('\\', f);
-        c = 'r';
-        break;
-      case '\n':
-        c = 'n';
-      case '"':
-      case '\\':
-        putc_unlocked('\\', f);
-    }
-    putc_unlocked(c, f);
-  }
-}
-
 void synctex_scan(fz_context *ctx, synctex_t *stx, fz_buffer *buf, unsigned page, int x, int y)
 {
   if (synctex_page_count(stx) <= page)
@@ -572,8 +548,6 @@ void synctex_scan(fz_context *ctx, synctex_t *stx, fz_buffer *buf, unsigned page
             c.rect.x0, c.rect.y0, c.rect.x1, c.rect.y1,
             len, filename,
             c.link.line, c.link.column);
-    fprintf(stdout, "(synctex \"");
-    output_sexp_string(stdout, (const void *)filename, len);
-    fprintf(stdout, "\" %d %d)\n", c.link.line, c.link.column);
+    editor_synctex((const void *)filename, len, c.link.line, c.link.column);
   }
 }

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -614,7 +614,7 @@ rev_parse_page(synctex_t *stx, fz_buffer *buf, const uint8_t *ptr, int tag, int 
   struct record r = {0,};
   while ((ptr = parse_line(ptr, &r)))
   {
-    if (r.link.tag-1 == tag && r.link.line >= line)
+    if (r.kind == STEX_CURRENT && r.link.tag - 1 == tag && r.link.line >= line)
     {
       if (x) *x = r.point.x;
       if (y) *y = r.point.y;

--- a/src/synctex.h
+++ b/src/synctex.h
@@ -40,4 +40,9 @@ void synctex_page_offset(fz_context *ctx, synctex_t *stx, unsigned index, int *b
 int synctex_input_offset(fz_context *ctx, synctex_t *stx, unsigned index);
 void synctex_scan(fz_context *ctx, synctex_t *stx, fz_buffer *buf, unsigned page, int x, int y);
 
+int synctex_has_target(synctex_t *stx);
+void synctex_set_target(synctex_t *stx, const char *path, int line);
+int synctex_find_target(fz_context *ctx, synctex_t *stx, fz_buffer *buf,
+                        int *page, int *x, int *y);
+
 #endif // SYNCTEX_H_


### PR DESCRIPTION
This PR adds a `(synctex-forward "path" line)` that the editor can send to scroll the preview around a specific source position.

The current code works but is very rough:
- scrolling could be smoother (sometimes, it takes a few attempts to properly center)
- it sometimes fail if the page is too far away from the current page (not really a problem during edition, but still buggy)
- only vertical scrolling is implemented for now