### PR TITLE
Reprot: unix socket passing based protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build/objects:
 ifeq ($(UNAME), Linux)
 Makefile.config: Makefile
 	echo >$@ "CC=gcc -O2 -ggdb -I. -fPIC"
-	echo >>$@ "LIBS=-lmupdf -lm $(shell ./mupdf-config.sh) -lz -ljpeg -ljbig2dec -lharfbuzz -lfreetype -lopenjp2 -lgumbo -lSDL2"
+	echo >>$@ "LIBS=-lmupdf -lm `./mupdf-config.sh` -lz -ljpeg -ljbig2dec -lharfbuzz -lfreetype -lopenjp2 -lgumbo -lSDL2"
 	echo >>$@ "TECTONIC_ENV="
 endif
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -52,7 +52,6 @@ txp_engine *txp_create_dvi_engine(fz_context *ctx,
 
 typedef enum {
   DOC_RUNNING,
-  DOC_BACK,
   DOC_TERMINATED
 } txp_engine_status;
 

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -221,6 +221,7 @@ static void close_process(struct tex_engine *self)
 static void pop_process(fz_context *ctx, struct tex_engine *self)
 {
   close_process(self);
+  channel_reset(self->c);
   self->process_count -= 1;
   if (self->process_count > 0)
     log_rollback(ctx, self->log, get_process(self)->snap);
@@ -812,6 +813,7 @@ static int answer_query(fz_context *ctx, struct tex_engine *self, query_t *q)
     case Q_CHLD:
     {
       self->process_count += 1;
+      channel_reset(self->c);
       if (self->process_count > 32)
         mabort();
       process_t *p2 = get_process(self);

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -982,12 +982,12 @@ static bool engine_step(txp_engine *_self, fz_context *ctx, bool restart_if_need
     if (!read_query(self, self->c, &q))
       return 0;
     int result = answer_query(ctx, self, &q);
+    channel_flush(self->c, p->fd);
     if (result == -1)
     {
-      // need backtrack
+      pop_process(ctx, self);
       return 1;
     }
-    channel_flush(self->c, p->fd);
     return result;
   }
   return 0;

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -244,8 +244,10 @@ static void decimate_processes(struct tex_engine *self)
   for  (int i = 0; i < self->process_count; ++i)
   {
     process_t *p = &self->processes[i];
-    fprintf(stderr, "- position %d, time %dms\n", p->trace_len,
-            p->trace_len == 0 ? 0 : self->trace[p->trace_len - 1].time);
+    fprintf(stderr, "- position %d, time %dms [pid %d]\n",
+            p->trace_len,
+            p->trace_len == 0 ? 0 : self->trace[p->trace_len - 1].time,
+            p->pid);
   }
 
   int i = 0, bound = (self->process_count - 8) / 2;
@@ -266,8 +268,10 @@ static void decimate_processes(struct tex_engine *self)
   for  (int i = 0; i < self->process_count; ++i)
   {
     process_t *p = &self->processes[i];
-    fprintf(stderr, "- position %d, time %dms\n", p->trace_len,
-            p->trace_len == 0 ? 0 : self->trace[p->trace_len - 1].time);
+    fprintf(stderr, "- position %d, time %dms [pid %d]\n",
+            p->trace_len,
+            p->trace_len == 0 ? 0 : self->trace[p->trace_len - 1].time,
+            p->pid);
   }
 }
 

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -841,7 +841,8 @@ static void rollback(fz_context *ctx, struct tex_engine *self, int trace)
 {
   fprintf(
     stderr,
-    "before rollback: %d bytes of output\n",
+    "rolling back to position %d\nbefore rollback: %d bytes of output\n",
+    trace,
     output_length(self->st.document.entry)
   );
   if (self->fence_pos < 0)
@@ -849,6 +850,24 @@ static void rollback(fz_context *ctx, struct tex_engine *self, int trace)
     fprintf(stderr, "No fences, assuming process finished\n");
     if (self->process_count > 0)
       mabort();
+  }
+
+  fprintf(stderr, "Last trace entries:\n");
+  for (int i = get_process(self)->trace_len - 1, j = 10; i > 0 && j > 0; i--, j--)
+  {
+    fprintf(stderr, "- %d->%d, %s, %dms\n",
+            self->trace[i].seen_before,
+            self->trace[i].seen_after,
+            self->trace[i].entry->path,
+            self->trace[i].time);
+  }
+
+  fprintf(stderr, "Snapshots:\n");
+  for  (int i = 0; i < self->process_count; ++i)
+  {
+    process_t *p = &self->processes[i];
+    fprintf(stderr, "- position %d, time %dms\n", p->trace_len,
+            p->trace_len == 0 ? 0 : self->trace[p->trace_len - 1].time);
   }
 
   while (self->process_count > 0 && get_process(self)->trace_len > trace)

--- a/src/main.c
+++ b/src/main.c
@@ -655,13 +655,14 @@ static void interpret_change(struct persistent_state *ps,
   if ((page_count == ui->page - 2 || page_count == ui->page - 1) &&
       send(get_status, ui->eng) == DOC_RUNNING &&
       delayed_changes.count < BUFFERED_OPS &&
-      cursor + plen + 1 + length + line_based <= BUFFERED_CHARS)
+      cursor + plen + 1 + length <= BUFFERED_CHARS)
   {
     char *op_path = delayed_changes.buffer + cursor;
     memcpy(op_path, path, plen + 1);
     cursor += plen + 1;
     char *op_data = delayed_changes.buffer + cursor;
     memcpy(op_data, data, length);
+    cursor += length;
     delayed_changes.cursor = cursor;
 
     delayed_changes.op[delayed_changes.count] = (struct delayed_op){

--- a/src/sprotocol.c
+++ b/src/sprotocol.c
@@ -136,7 +136,7 @@ static void write_all(int fd, const char *buf, int size)
     {
       if (errno == EINTR)
         continue;
-      pabort();
+      perror("sprotocol.c write_all");
     }
     if (n == 0)
       abort();

--- a/src/sprotocol.c
+++ b/src/sprotocol.c
@@ -174,6 +174,8 @@ bool channel_handshake(channel_t *c, int fd)
   char answer[LEN(HND_CLIENT)];
   write_all(fd, HND_SERVER, LEN(HND_SERVER));
   read_all(c, fd, answer, LEN(HND_CLIENT));
+  c->input.len = c->input.pos = 0;
+  c->output.pos = 0;
   return (strncmp(HND_CLIENT, answer, LEN(HND_CLIENT)) == 0);
 }
 

--- a/src/sprotocol.c
+++ b/src/sprotocol.c
@@ -659,6 +659,12 @@ void channel_flush(channel_t *t, int fd)
   cflush(t, fd);
 }
 
+void channel_reset(channel_t *t)
+{
+  t->input.pos = t->input.len = 0;
+  t->output.pos = 0;
+}
+
 void *channel_get_buffer(channel_t *t, size_t n)
 {
   while (n > t->buf_size)

--- a/src/sprotocol.h
+++ b/src/sprotocol.h
@@ -33,7 +33,7 @@
 typedef struct channel_s channel_t;
 typedef int file_id;
 
-#define LOG 1
+#define LOG 0
 
 #define LEN(txt) (sizeof(txt)-1)
 #define STR(X) #X

--- a/src/sprotocol.h
+++ b/src/sprotocol.h
@@ -220,6 +220,7 @@ void channel_write_ask(channel_t *t, int fd, ask_t *a);
 void channel_write_answer(channel_t *t, int fd, answer_t *a);
 void *channel_get_buffer(channel_t *t, size_t n);
 void channel_flush(channel_t *t, int fd);
+void channel_reset(channel_t *t);
 
 void log_query(FILE *f, query_t *q);
 #endif /*!SPROTOCOL_H*/

--- a/src/sprotocol.h
+++ b/src/sprotocol.h
@@ -33,7 +33,7 @@
 typedef struct channel_s channel_t;
 typedef int file_id;
 
-#define LOG 0
+#define LOG 1
 
 #define LEN(txt) (sizeof(txt)-1)
 #define STR(X) #X
@@ -60,6 +60,7 @@ enum query {
   Q_STAT = PACK('S','T','A','T'),
   Q_GPIC = PACK('G','P','I','C'),
   Q_SPIC = PACK('S','P','I','C'),
+  Q_CHLD = PACK('C','H','L','D'),
 };
 
 enum accs_flag {
@@ -102,11 +103,9 @@ typedef struct {
       int pos;
     } seen;
     struct {
+      int fd;
       int pid;
     } chld;
-    struct {
-      int pid, cid, exitcode;
-    } back;
     struct {
       char *path;
       int flags;

--- a/src/sprotocol.h
+++ b/src/sprotocol.h
@@ -56,8 +56,6 @@ enum query {
   Q_CLOS = PACK('C','L','O','S'),
   Q_SIZE = PACK('S','I','Z','E'),
   Q_SEEN = PACK('S','E','E','N'),
-  Q_CHLD = PACK('C','H','L','D'),
-  Q_BACK = PACK('B','A','C','K'),
   Q_ACCS = PACK('A','C','C','S'),
   Q_STAT = PACK('S','T','A','T'),
   Q_GPIC = PACK('G','P','I','C'),
@@ -193,7 +191,6 @@ typedef struct {
 /* "ASK" :P */
 
 enum ask {
-  C_TERM = PACK('T','E','R','M'),
   C_FLSH = PACK('F','L','S','H'),
 };
 
@@ -214,16 +211,16 @@ typedef struct {
 
 /* Functions */
 
-channel_t *channel_new(int fd);
+channel_t *channel_new(void);
 void channel_free(channel_t *c);
 
-bool channel_handshake(channel_t *c);
-bool channel_has_pending_query(channel_t *t, int timeout);
-bool channel_read_query(channel_t *t, query_t *r);
-void channel_write_ask(channel_t *t, ask_t *a);
-void channel_write_answer(channel_t *t, answer_t *a);
-void *channel_write_buffer(channel_t *t, size_t n);
-void channel_flush(channel_t *t);
+bool channel_handshake(channel_t *c, int fd);
+bool channel_has_pending_query(channel_t *t, int fd, int timeout);
+bool channel_read_query(channel_t *t, int fd, query_t *r);
+void channel_write_ask(channel_t *t, int fd, ask_t *a);
+void channel_write_answer(channel_t *t, int fd, answer_t *a);
+void *channel_get_buffer(channel_t *t, size_t n);
+void channel_flush(channel_t *t, int fd);
 
 void log_query(FILE *f, query_t *q);
 #endif /*!SPROTOCOL_H*/


### PR DESCRIPTION
This branch revisit the IPC protocol.
It used to be synchronous, with all processes sharing a common socket and following a strict "stack" policy: a parent waited for its child to terminate before resuming communication.
This caused a lot of problems: headache when resuming/suspending, complicating the protocol, sometimes leaving stale data in buffer, and the strict hierarchy was too limiting (occasionnally, we want to "collect" older snapshots, deep in the stack, that are not that useful).

This branch solves all the problems by having each process uses its own socket: when forking, the child gets a new socket and the parent sends the other end to the driver by passing fd as ancillary data.