### PR TITLE
Build patches for fedora 39 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,16 @@ config: Makefile.config build/objects
 build/objects:
 	mkdir -p build/objects
 
+# LDCC: some Linux distribution build mupdf with C++ dependencies,
+# Fedora needs -lleptonica and -ltesseract; so we use a C++ compiler
+# for the linking step.
+
 ifeq ($(UNAME), Linux)
 Makefile.config: Makefile
-	echo >$@ "CC=gcc -O2 -ggdb -I. -fPIC"
-	echo >>$@ "LIBS=-lmupdf -lm `./mupdf-config.sh` -lz -ljpeg -ljbig2dec -lharfbuzz -lfreetype -lopenjp2 -lgumbo -lSDL2"
+	echo >$@ "CFLAGS=-O2 -ggdb -I. -fPIC"
+	echo >>$@ 'CC=gcc $$(CFLAGS)'
+	echo >>$@ 'LDCC=g++ $$(CFLAGS)'
+	echo >>$@ "LIBS=-lmupdf -lm `./mupdf-config.sh` -lz -ljpeg -ljbig2dec -lharfbuzz -lfreetype -lopenjp2 -lgumbo -lSDL2 -lleptonica -ltesseract"
 	echo >>$@ "TECTONIC_ENV="
 endif
 
@@ -38,7 +44,9 @@ ifeq ($(UNAME), Darwin)
 BREW=$(shell brew --prefix)
 BREW_ICU4C=$(shell brew --prefix icu4c)
 Makefile.config: Makefile
-	echo >$@ "CC=gcc -O2 -ggdb -I. -fPIC -I$(BREW)/include"
+	echo >$@ "CFLAGS=-O2 -ggdb -I. -fPIC"
+	echo >>$@ 'CC=gcc $$(CFLAGS)'
+	echo >>$@ 'LDCC=gcc $$(CFLAGS)'
 	echo >>$@ "LIBS=-L$(BREW)/lib -lmupdf -lm -lmupdf-third -lz -ljpeg -ljbig2dec -lharfbuzz -lfreetype -lopenjp2 -lgumbo -lSDL2"
 	echo >>$@ "TECTONIC_ENV=PKG_CONFIG_PATH=$(BREW_ICU4C)/lib/pkgconfig"
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Otherwise, read below.
 
 ## Build TeXpresso
 
-First make sure the dependencies are available: `pkg-config`, `re2c`, `SDL2`, `mupdf` (and its own dependencies: `libjpeg`, `libpng`, `freetype2`, `gumbo`, ...).
+First make sure the dependencies are available: `pkg-config`, `re2c`, `SDL2`, `mupdf` (and its own dependencies: `libjpeg`, `libpng`, `freetype2`, `gumbo`, `jbig2dec`... and possibly `leptonica` and `tesseract` depending on the mupdf version).
 Under macOS, `brew` is also used to find local files.
 
 If it succeeds, `make texpresso` produces `build/texpresso`.
@@ -38,7 +38,7 @@ Other targets are:
 - `clean` to remove intermediate build files
 - `distclean` to remove all build files (`build/` and `Makefile.config`)
 
-If build fails, try tweaking the configuration flags in `Makefile.config`.
+If the build fails, try tweaking the configuration flags in `Makefile.config`.
 
 ## Build TeXpresso-tonic (Tectonic)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,21 +10,21 @@ all: $(TARGETS)
 
 texpresso: $(BUILD)/texpresso
 $(BUILD)/texpresso: $(DIR)/driver.o $(DIR)/main.o $(DIR)/logo.o $(DIR_OBJECTS) $(DIR)/libmydvi.a
-	$(CC) -o $@ $^ $(LIBS)
+	$(LDCC) -o $@ $^ $(LIBS)
 
 texpresso-dev: $(BUILD)/texpresso-dev
 $(BUILD)/texpresso-dev: $(DIR)/driver.o $(DIR)/loader.o $(DIR)/logo.o | $(BUILD)/texpresso-dev.so
-	$(CC) -o $@ $^ $(LIBS)
+	$(LDCC) -o $@ $^ $(LIBS)
 
 texpresso-dev.so: $(BUILD)/texpresso-dev.so
 $(BUILD)/texpresso-dev.so: $(DIR)/main.o $(DIR_OBJECTS) $(DIR)/libmydvi.a
 	$(MAKE) -C dvi
-	$(CC) -ldl -shared -o $@ $^ $(LIBS)
+	$(LDCC) -ldl -shared -o $@ $^ $(LIBS)
 	killall -SIGUSR1 texpresso-dev || true
 
 texpresso-debug-proxy: $(BUILD)/texpresso-debug-proxy
 $(BUILD)/texpresso-debug-proxy: proxy.c
-	$(CC) -o $@ $^
+	$(LDCC) -o $@ $^
 
 texpresso-debug: $(BUILD)/texpresso-debug
 $(BUILD)/texpresso-debug: ../scripts/texpresso-debug

--- a/src/dvi/dvi_special.c
+++ b/src/dvi/dvi_special.c
@@ -40,7 +40,7 @@ typedef const char *cursor_t;
 
 re2c:yyfill:enable = 0;
 re2c:eof = -1;
-re2c:api = custom;
+re2c:flags:input = custom;
 re2c:api:style = free-form;
 re2c:define:YYCURSOR    = cur;
 re2c:define:YYCTYPE     = int;

--- a/src/dvi/pdf_lexer.c
+++ b/src/dvi/pdf_lexer.c
@@ -33,7 +33,7 @@ typedef const char *cursor_t;
 
 re2c:yyfill:enable = 0;
 re2c:eof = -1;
-re2c:api = custom;
+re2c:flags:input = custom;
 re2c:api:style = free-form;
 re2c:define:YYCURSOR    = *cur;
 re2c:define:YYCTYPE     = int;


### PR DESCRIPTION
I am not sure that it is a good idea to add `-lleptonica -ltesseract` unconditionally to all Linux builds, but I am too lazy to figure out how to make it conditional. Feel free to steal the patches and hack on them without merging.