### PR TITLE
Minor README tweaks

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,6 +73,17 @@ Install all dependencies:
 sudo dnf install make gcc mupdf-devel SDL2-devel re2c g++ freetype2-devel libjpeg-turbo-devel jbig2dec-devel openjpeg2-devel gumbo-parser-devel tesseract-devel leptonica-devel cargo openssl-devel fontconfig-devel
 ```
 
+## Download
+
+Simply clone the git repository (and its submodules) using one of the following commands:
+
+```
+git clone --recurse-submodules https://github.com/let-def/texpresso.git   # cloning by HTTP
+git clone --recurse-submodules git@github.com:let-def/texpresso.git       # cloning by SSH
+```
+
+(You may want to adjust the URL if you are looking at a different fork.)
+
 ## Build TeXpresso
 
 First make sure the dependencies are available: `pkg-config`, `re2c`, `SDL2`, `mupdf` (and its own dependencies: `libjpeg`, `libpng`, `freetype2`, `gumbo`, `jbig2dec`... and possibly `leptonica`, `tesseract` and `mujs` depending on the mupdf version).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,6 +84,8 @@ git clone --recurse-submodules git@github.com:let-def/texpresso.git       # clon
 
 (You may want to adjust the URL if you are looking at a different fork.)
 
+Note that while TeXpresso itself (the driver/viewer program) is small (less than 2MiB of sources, about 40MiB once built), the `tectonic` LaTeX engine that we include as a submodule is large -- 120MiB of sources, most of it from its `harfbuzz` dependency, and about 1.2GiB once built.
+
 ## Build TeXpresso
 
 First make sure the dependencies are available: `pkg-config`, `re2c`, `SDL2`, `mupdf` (and its own dependencies: `libjpeg`, `libpng`, `freetype2`, `gumbo`, `jbig2dec`... and possibly `leptonica`, `tesseract` and `mujs` depending on the mupdf version).

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ TeXpresso comes with an Emacs mode. The source can be found in
 Start TeXpresso with `M-x texpresso`. The prompt will let you select the master/root TeX file.
 It will try to start the `texpresso` command. If it is not possible, it will open
 `(customize-variable 'texpresso-binary)` to let you set the path to texpresso
-binary.
+binary (`<where you cloned the repository>/build/texpresso`).
 
 To work correctly, `texpresso` needs `texpresso-tonic` helper; when copying them, make sure they are both in the same directory.
 


### PR DESCRIPTION
I just watched a less-technical user install TeXpresso by following the README+INSTALL instructions. Here are two small tweaks:

1. In the INSTALL.md file, include a full `git clone` command -- this was less useful when the instructions where in the README.md, as the page would be viewed in the context of the full repository with the green `code` button, but it is harder to find now. (This hardcodes the link to the current repository in INSTALL.md)

   (Note: I included a description of the cloned size (about 120MiB on my machine) and the post-build size (about 1.2GiB on my machine.)

2. In the README.md instructions for Emacs, be more explicitly about what is the path to the texpresso binary.