### PR TITLE
Handle infinite loops & race conditions with latest process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Re-enable SyncTeX (accidentally disabled during a rebase)
 - Fix a crash when the same file was opened multiple times
 - Disable compositor bypass (#50, report by @adamkruszewski)
+- Handle infinite loops in TeX code
+- Fix race conditions when latest process observe data being changed
 
 # v0.0 Fri Apr  5 06:52:52 JST 2024
 

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -1058,7 +1058,7 @@ static bool engine_step(txp_engine *_self, fz_context *ctx, bool restart_if_need
     if (fd == -1)
       return 0;
     if (!channel_has_pending_query(self->c, fd, 10))
-      return 1;
+      return 0;
     if (!read_query(self, self->c, &q))
     {
       close(fd);

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -1165,14 +1165,19 @@ static bool rollback_end(fz_context *ctx, struct tex_engine *self, int *tracep, 
   // Check if nothing changed
   if (trace_len == p->trace_len)
   {
-    if (p->fd > -1 && self->rollback.flush)
+    if (!self->rollback.flush)
+      return false;
+    if (p->fd > -1)
     {
       ask_t a;
       a.tag = C_FLSH;
       channel_write_ask(self->c, p->fd, &a);
       channel_flush(self->c, p->fd);
+      return false;
     }
-    return false;
+    trace_len -= 1;
+    if (trace_len > 0)
+      self->rollback.offset = self->trace[trace_len].seen;
   }
 
   fprintf(stderr, "[change] rewinded trace from %d to %d entries\n",

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -1186,6 +1186,60 @@ static bool rollback_end(fz_context *ctx, struct tex_engine *self, int *tracep, 
   return true;
 }
 
+// Return false if some contents had not been observed: caller should recheck
+// for changed contents.
+// Return true otherwise (process is ready to be flushed).
+static bool check_if_everything_seen(fz_context *ctx, struct tex_engine *self)
+{
+  // If the process is marked ready to flush, seen messages have already been
+  // consumed
+  if (self->rollback.flush)
+    return 1;
+
+  process_t *p = get_process(self);
+
+  // If process is dead, nothing has been missed
+  if (p->fd == -1)
+    return 1;
+
+  // Synchronize with the child process:
+  // - kill if stuck
+  // - check pending SEEN messages to update vision of the process
+  int nothing_seen = 1;
+  do {
+    if (!channel_has_pending_query(self->c, p->fd, 10))
+    {
+      fprintf(stderr, "[kill] worker might be stuck, killing\n");
+      // The process hasn't answered in 10ms
+      // It might be stuck in long computation or a loop, kill it to start from the previous one.
+      close_process(p);
+      break;
+    }
+    // Process only pending SEEN to have an updated view on process state
+    switch (channel_peek_query(self->c, p->fd))
+    {
+      case Q_SEEN:
+        {
+          query_t q;
+          if (!read_query(self, self->c, &q))
+          {
+            close(p->fd);
+            p->fd = -1;
+            break;
+          }
+          answer_query(ctx, self, &q);
+          nothing_seen = 0;
+          continue;
+        }
+      default:
+        break;
+    }
+  } while(0);
+
+  self->rollback.flush = 1;
+  return nothing_seen;
+}
+
 static void rollback_add_change(fz_context *ctx, struct tex_engine *self, fileentry_t *e, int changed)
 {
   int trace_len = self->rollback.trace_len;
@@ -1197,8 +1251,8 @@ static void rollback_add_change(fz_context *ctx, struct tex_engine *self, fileen
 
   if (e->seen < changed)
   {
-    self->rollback.flush = 1;
-    return;
+    if (check_if_everything_seen(ctx, self) || e->seen < changed)
+      return;
   }
 
   while (e->seen >= changed)

--- a/src/main.c
+++ b/src/main.c
@@ -200,7 +200,7 @@ static bool advance_engine(fz_context *ctx, ui_state *ui)
         (curr.tv_sec - start.tv_sec) * 1000 * 1000 * 1000 +
         (curr.tv_nsec - start.tv_nsec);
 
-      if (delta > 1000000)
+      if (delta > 5000000)
         break;
     }
   }

--- a/src/sprotocol.c
+++ b/src/sprotocol.c
@@ -471,6 +471,15 @@ bool channel_has_pending_query(channel_t *t, int fd, int timeout)
   return 1;
 }
 
+enum query channel_peek_query(channel_t *t, int fd)
+{
+  uint32_t result = read_u32(t, fd);
+  if (result == 0)
+    abort();
+  t->input.pos -= 4;
+  return result;
+}
+
 bool channel_read_query(channel_t *t, int fd, query_t *r)
 {
   uint32_t tag;

--- a/src/sprotocol.h
+++ b/src/sprotocol.h
@@ -190,6 +190,7 @@ void channel_free(channel_t *c);
 
 bool channel_handshake(channel_t *c, int fd);
 bool channel_has_pending_query(channel_t *t, int fd, int timeout);
+enum query channel_peek_query(channel_t *t, int fd);
 bool channel_read_query(channel_t *t, int fd, query_t *r);
 void channel_write_ask(channel_t *t, int fd, ask_t *a);
 void channel_write_answer(channel_t *t, int fd, answer_t *a);


### PR DESCRIPTION
Improve support for infinite loops in TeX code, e.g. `\newcommand\x{\x}\x`.

When reading that kind of code, TeXpresso was often waiting mindlessly on the latest process, seemingly not processing changes.

If a change happened close to the loop construction, it is likely that no `seen` event had been received yet because the worker is busy. So TeXpresso thought the contents was not observed and that it was still possible to invalidate the buffers. There are three bugs there:

1) If the process is really stuck on an infinite loop, the flush message will never be processed and the UI will freeze too. Removing the loop is not sufficient because the TeXpresso is never made aware that it has been observed. 
2) If the process is performing a long computation, there likely is a race condition: the flush message will be exchanged before TeXpresso is made aware of the actually observed contents.
3) In both cases, the UI was sluggish because TeXpresso favored waiting on the worker over processing UI events.

This PR fixes the three issues.

For 1 & 2, we synchronize with the worker by consuming any pending SEEN before flushing. Three outcomes are possible: synchronization failed (infinite loop), and the worker is killed (fixes 1), synchronization succeeded and the contents is still valid (case 2 when the race condition does not trigger): flushing is sufficient, nothing else needs to be done, synchronization succeeded and the buffer has to be invalidated: we fallback to the usual change handling code path.

The kill case needs a bit more care: computing fences will be done without precise knowledge of the invalidated area, and rollback_processes will have to deal with a dead worker. I think the current solution is correct but I might have missed some cases.
 
For 3, the timing heuristics are changed: if the worker doesn't answer within 10ms, the code fallback to UI processing.
If the worker does answer, events are processed by batches of 10 until either 5ms were spent or one event took more than 10ms.

The worst case latency is to have the first 10 events to happen in less than 5ms, followed by the next 9 that all answers just before the timeout and the 10th that timeout. In total : 5-eps + 9 * (10 - eps) + 10 = 105ms-eps. This is very unlikely and not accounted for at the moment. The batch processing is probably useless: the only overhead it avoids is clock_gettime, which is negligible compared to the I/O and IPCs involved with worker event processing. However I have kept this code at it is at the moment: "it ain't broken yet", I will change it if it becomes problematic in the future.