### PR TITLE
Workaround fork limitations on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Disable compositor bypass (#50, report by @adamkruszewski)
 - Handle infinite loops in TeX code
 - Fix race conditions when latest process observe data being changed
+- Workaround limitations of fork on macOS when using system fonts
 
 # v0.0 Fri Apr  5 06:52:52 JST 2024
 

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -10,7 +10,9 @@
 \title{TeXpresso manual}
 \author{Frédéric Bour}
 
-\setmainfont{Cabin}
+\renewcommand{\familydefault}{\sfdefault}
+
+%\setmainfont{Cabin}
 %[
 %  Extension = .otf,
 %  UprightFont = *-Regular,
@@ -151,6 +153,31 @@ with {\em contents} (the real filesystem is not actually changed, only the view 
 \paragraph{Notification channels.} These commands are used by \txp to share the standard output and the log file of the underlying \LaTeX{} process.
 
 \texttt{(append out|log "text")} appends {\em "text"} to the standard output (if the second argument is {\em out}) or the log file (if the second argument is {\em log}). Emacs interpets this by adding this text to the \texttt{*texpresso-out} or \texttt{*texpresso-log*} buffers.
+
+\section{Limitations}
+
+\subsection{Using system fonts on macOS}
+
+To load a system font, XeTeX needs to connect to a system service. 
+Unfortunately using system services interferes with TeXpresso's approach to snapshotting.
+
+We recommend that you avoid using system fonts. It is a good practice anyway as system fonts are less portable. Instead, you can use the \texttt{fontspec} package to load a local font file (provided in \texttt{.ttf} or \texttt{.otf} format). This provides stronger reproducibility guarantees and works well with TeXpresso.
+
+If you really need to load system fonts, try loading all of them in the preamble. TeXpresso will still misbehave if you interactively update the preamble (be prepared to restart the process from time to time), but it should work well when working on the rest of the document.
+
+FIXME: Add a hotkey to manually restart \LaTeX{} processes when interactivity breaks.
+
+\paragraph{Technical details.}
+
+TeXpresso uses \texttt{fork(2)} to take snapshots of \LaTeX{} processes. This comes with two important limitations on macOS:
+\begin{itemize}
+  \item forking a multi-threaded process is quite unstable,
+  \item a forked process lose connections to system services.
+\end{itemize}
+
+Forking a multi-threaded process also leads to undefined behaviors on Linux. Fortunately, stopping other threads before forking proved sufficient to get a stable behavior on Linux/glibc at least, but not on macOS. Instead, we fixed TeXpresso's design to only fork single-threaded processes. 
+
+Unfortunately, we were not able to fix the second limitation, and system services are used to load fonts.
 
 \section{Plan}
 \begin{itemize}

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -468,6 +468,18 @@ static bool need_snapshot(fz_context *ctx, struct tex_engine *self, int time)
   }
   else
   {
+    #ifdef __APPLE__
+    // Workaround for macOS
+    // Due to limitations in the implementation of fork on macOS, it is not
+    // possible to load system fonts after fork (without exec). This breaks
+    // TeXpresso sooner or later, and there is no obvious solution besides
+    // implementing XeTeX snapshotting without fork.
+    // The second best thing is to hopefully load all system fonts before the
+    // first fork. Therefore we delay all "unnecessary" forks: we try to only
+    // fork after a first edition.
+    return 0;
+    #endif
+
     // No snapshot, measure time since root process started
     last_time = 0;
   }

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -475,9 +475,11 @@ static bool need_snapshot(fz_context *ctx, struct tex_engine *self, int time)
     // TeXpresso sooner or later, and there is no obvious solution besides
     // implementing XeTeX snapshotting without fork.
     // The second best thing is to hopefully load all system fonts before the
-    // first fork. Therefore we delay all "unnecessary" forks: we try to only
-    // fork after a first edition.
-    return 0;
+    // first fork.
+    // Therefore we delay forking until output started, hopping that all fonts
+    // have been specified at this point.
+    if (!incdvi_output_started(self->dvi))
+      return 0;
     #endif
 
     // No snapshot, measure time since root process started

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -146,6 +146,13 @@ static pid_t exec_xelatex_generic(char **args, int *fd)
   setenv("TEXPRESSO_FD", buf, 1);
 
 #ifdef __APPLE__
+  static int env_init = 0;
+  if (!env_init)
+  {
+    env_init = 1;
+    setenv("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES", 1);
+  }
+
   pid_t pid = fork();
 #else
   pid_t pid = vfork();

--- a/src/incdvi.c
+++ b/src/incdvi.c
@@ -140,6 +140,11 @@ void incdvi_update(fz_context *ctx, incdvi_t *d, fz_buffer *buf)
     d->fontdef_offset = d->offset;
 }
 
+bool incdvi_output_started(incdvi_t *d)
+{
+  return (d->page_len > 0);
+}
+
 int incdvi_page_count(incdvi_t *d)
 {
   return (d->page_len / 2);

--- a/src/incdvi.h
+++ b/src/incdvi.h
@@ -35,6 +35,7 @@ incdvi_t *incdvi_new(fz_context *ctx, dvi_reshooks hooks);
 void incdvi_free(fz_context *ctx, incdvi_t *d);
 void incdvi_reset(incdvi_t *d);
 void incdvi_update(fz_context *ctx, incdvi_t *d, fz_buffer *buf);
+bool incdvi_output_started(incdvi_t *d);
 int incdvi_page_count(incdvi_t *d);
 void incdvi_page_dim(incdvi_t *d, fz_buffer *buf, int page, float *width, float *height, bool *landscape);
 void incdvi_render_page(fz_context *ctx, incdvi_t *d, fz_buffer *buf, int page, fz_device *dev);


### PR DESCRIPTION
To use system fonts on macOS, XeTeX has to use some services that are not available to process that forked (without exec).
There are two possible failure modes:
- on recent macOS, invalid usage of fork are detected and the process aborts after emitting an error message; this is a conservative check that sometimes reject "correct" uses, and it can be disabled by setting the env `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`
- an actual invalid use of fork will crash the process with an invalid access / SIGSEGV.

It is therefore not possible to load a new system font after TeXpresso forked. As a best-effort:
- TeXpresso sets `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`, to keep going as long as possible, hopping that no new fonts will be loaded
- it does not fork before output has started (after execution of the preamble); that way, if fonts are loaded in the preamble, the rest of the document should be editable interactively (without causing crashes)

This is only a workaround, not a complete solution: it is still possible to crash TeXpresso by loading system fonts in the middle of the document, or by editing the preamble while live rendering.

The safest option is to not use system fonts: stick to TeX fonts or use local ttf/otf fonts (specified using `fontspec` commands with `Path` modifier).