### PR TITLE
move (pan?) within the page on UP/DOWN

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The driver sends information between the editor and the renderer in both directi
 
 Keyboard controls:
 - `←`, `→`: change page
+- `↑`, `↓`: move within the page
 - `p` (for "page"): switch between "fit-to-page" and "fit-to-width" zoom modes
 - `c` ("crop"): crop borders
 - `q` ("quit"): quit

--- a/src/main.c
+++ b/src/main.c
@@ -480,8 +480,8 @@ static void ui_pan(fz_context *ctx, ui_state *ui, float factor)
   float delta = bounds.window_size.y * scale.y * factor;
   float range = bounds.pan_interval.y < 0 ? 0 : bounds.pan_interval.y;
 
-  fprintf(stderr, "ui_pan: factor:%.02f delta:%.02f current:%.02f range:%.02f\n",
-          factor, delta, config->pan.y, range);
+  //fprintf(stderr, "ui_pan: factor:%.02f delta:%.02f current:%.02f range:%.02f\n",
+  //        factor, delta, config->pan.y, range);
 
   if (config->pan.y == -range && factor < 0)
   {

--- a/src/main.c
+++ b/src/main.c
@@ -1188,11 +1188,11 @@ bool texpresso_main(struct persistent_state *ps)
             break;
 
           case SDLK_UP:
-            ui_pan(ps->ctx, ui, 0.9);
+            ui_pan(ps->ctx, ui, 2.0/3.0);
             break;
 
           case SDLK_DOWN:
-            ui_pan(ps->ctx, ui, -0.9);
+            ui_pan(ps->ctx, ui, -2.0/3.0);
             break;
 
           case SDLK_RIGHT:

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -233,6 +233,7 @@ bool txp_renderer_page_bounds(fz_context *ctx, txp_renderer *self, txp_renderer_
     doc_w = doc_h * doc_ar;
   }
 
+  result->page_bounds   = bounds;
   result->window_size   = fz_make_point(self->output_w, self->output_h);
   result->document_size = fz_make_point(doc_w, doc_h);
   result->pan_interval  = fz_make_point((doc_w - self->output_w) / 2.0,

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -241,7 +241,7 @@ int txp_renderer_page_position(fz_context *ctx, txp_renderer *self, SDL_FRect *p
   // fprintf(stderr, "after clamp: %.02f, %.02f\n", r->vp.pan.x, r->vp.pan.y);
 
   // fprintf(stderr, "doc size: (%.02f, %.02f), out size: (%d, %d)\n",
-  //         doc_w, doc_h, r->size.w, r->size.h);
+  //         doc_w, doc_h, self->output_w, self->output_h);
   // fprintf(stderr, "out_ar: %.02f, doc_ar: %.02f, cx: %.02f, cy: %.02f\n",
   //         out_ar, doc_ar, cx, cy);
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -205,7 +205,7 @@ static fz_stext_page *get_stext(fz_context *ctx, txp_renderer *self)
   return self->stext;
 }
 
-int txp_renderer_page_position(fz_context *ctx, txp_renderer *self, SDL_FRect *prect, fz_point *ptranslate, float *pscale)
+bool txp_renderer_page_bounds(fz_context *ctx, txp_renderer *self, txp_renderer_bounds *result)
 {
   if (!self->contents)
     return 0;
@@ -233,8 +233,21 @@ int txp_renderer_page_position(fz_context *ctx, txp_renderer *self, SDL_FRect *p
     doc_w = doc_h * doc_ar;
   }
 
-  float cx = (doc_w - self->output_w) / 2.0;
-  float cy = (doc_h - self->output_h) / 2.0;
+  result->window_size   = fz_make_point(self->output_w, self->output_h);
+  result->document_size = fz_make_point(doc_w, doc_h);
+  result->pan_interval  = fz_make_point((doc_w - self->output_w) / 2.0,
+                                        (doc_h - self->output_h) / 2.0);
+
+  return 1;
+}
+
+bool txp_renderer_page_position(fz_context *ctx, txp_renderer *self, SDL_FRect *prect, fz_point *ptranslate, float *pscale)
+{
+  txp_renderer_bounds bounds;
+  if (!txp_renderer_page_bounds(ctx, self, &bounds))
+    return 0;
+
+  float cx = bounds.pan_interval.x, cy = bounds.pan_interval.y;
 
   self->config.pan.x = clampf(self->config.pan.x, -cx, cx);
   self->config.pan.y = clampf(self->config.pan.y, -cy, cy);
@@ -245,15 +258,15 @@ int txp_renderer_page_position(fz_context *ctx, txp_renderer *self, SDL_FRect *p
   // fprintf(stderr, "out_ar: %.02f, doc_ar: %.02f, cx: %.02f, cy: %.02f\n",
   //         out_ar, doc_ar, cx, cy);
 
-  float scale = doc_w / (bounds.x1 - bounds.x0);
+  float scale = bounds.document_size.x / (bounds.page_bounds.x1 - bounds.page_bounds.x0);
   float tx = self->config.pan.x - cx;
   float ty = self->config.pan.y - cy;
 
   if (prect)
-    *prect = (SDL_FRect){.x = tx, .y = ty, .w = doc_w, .h = doc_h};
+    *prect = (SDL_FRect){.x = tx, .y = ty, .w = bounds.document_size.x, .h = bounds.document_size.y};
 
   if (ptranslate)
-    *ptranslate = fz_make_point(tx - bounds.x0 * scale, ty - bounds.y0 * scale);
+    *ptranslate = fz_make_point(tx - bounds.page_bounds.x0 * scale, ty - bounds.page_bounds.y0 * scale);
 
   if (pscale)
     *pscale = scale;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -49,10 +49,29 @@ typedef struct
   uint32_t background_color, foreground_color;
 } txp_renderer_config;
 
+typedef struct
+{
+  // Bounds of the page being displayed (after cropping), in
+  // document space.
+  fz_rect page_bounds;
+
+  // Size of the window where the document is displayed.
+  fz_point window_size;
+
+  // Size of the page being displayed, in window space.
+  fz_point document_size;
+
+  // Panning range from -pan_interval to pan_interval.
+  fz_point pan_interval;
+} txp_renderer_bounds;
+
 void txp_renderer_set_contents(fz_context *ctx, txp_renderer *self, fz_display_list *dl);
 fz_display_list *txp_renderer_get_contents(fz_context *ctx, txp_renderer *self);
 txp_renderer_config *txp_renderer_get_config(fz_context* ctx, txp_renderer *self);
-int txp_renderer_page_position(fz_context *ctx, txp_renderer *self, SDL_FRect *rect, fz_point *translate, float *scale);
+
+bool txp_renderer_page_bounds(fz_context *ctx, txp_renderer *self, txp_renderer_bounds *result);
+bool txp_renderer_page_position(fz_context *ctx, txp_renderer *self, SDL_FRect *rect, fz_point *translate, float *scale);
+
 void txp_renderer_render(fz_context *ctx, txp_renderer *self);
 void txp_renderer_set_scale_factor(fz_context *ctx, txp_renderer *self, fz_point scale);
 bool txp_renderer_start_selection(fz_context *ctx, txp_renderer *self, fz_point pt);


### PR DESCRIPTION
I want a keyboard-only workflow to read PDF documents. Currently the texpresso viewer enables this in fit-height mode, but not in fit-width mode where I have to use the touchpad to scroll through the page.

This naive PR implements "pan up" and "pan down" actions when pressing up/down key. I can now browse through the document by hitting "down" until the end of the page, and then "right" to get to the next page.

Notes:
- I needed to add code to "reset the pan" on {previous,next}_page: when I am at the bottom of a page and press "right", I want to end up at the top of the next page, not at the same position. I briefly tried to understand the size computations to know which value of `pan.y` to set to be at the top of the page, and gave up; the code use `1. / 0.`. Feel free to suggest a better value -- or modify the patch, etc. (Note: previous_page also resets to the top of the page, I am not sure if people would want something different there, maybe start at the bottom of the page?)
- Ideally I could keep browsing with just up/down: when we hit the page boundary, "down" again would go to the next page. I am not familiar enough with the geometry stuff to implement this easily.
- the "pan down" action does not pan by exactly the viewer height, but by 0.9 times that. This helps provide some continuity in the content to know where to restart reading. It might be even better to smoothly scroll to the next position, but I don't know how to implement it, and it might be disturbing to some people, and I don't think it is necessary.
