### PR TITLE
Add input-file message

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -424,10 +424,10 @@ void editor_flush(void)
   switch (protocol)
   {
     case EDITOR_SEXP:
-      puts("(flush)\n");
+      fprintf(stdout, "(flush)\n");
       break;
     case EDITOR_JSON:
-      puts("[\"flush\"]\n");
+      fprintf(stdout, "[\"flush\"]\n");
       break;
   }
 }
@@ -462,10 +462,31 @@ void editor_reset_sync(void)
   switch (protocol)
   {
     case EDITOR_SEXP:
-      puts("(reset-sync)\n");
+      fprintf(stdout, "(reset-sync)\n");
       break;
     case EDITOR_JSON:
-      puts("[\"reset-sync\"]\n");
+      fprintf(stdout, "[\"reset-sync\"]\n");
       break;
+  }
+}
+
+void editor_notify_file_opened(int index, const char *path, int len)
+{
+  if (len == 0)
+    return;
+  switch (protocol)
+  {
+    case EDITOR_SEXP:
+      fprintf(stdout, "(input-file %d \"", index);
+      break;
+    case EDITOR_JSON:
+      fprintf(stdout, "[input-file\", %d, \"", index);
+      break;
+  }
+  output_data_string(stdout, path, len);
+  switch (protocol)
+  {
+    case EDITOR_SEXP: fprintf(stdout, "\")\n"); break;
+    case EDITOR_JSON: fprintf(stdout, "\"]\n"); break;
   }
 }

--- a/src/editor.h
+++ b/src/editor.h
@@ -103,5 +103,6 @@ void editor_truncate(enum EDITOR_INFO_BUFFER name, fz_buffer *buf);
 void editor_flush(void);
 void editor_synctex(const char *dirname, const char *basename, int basename_len, int line, int column);
 void editor_reset_sync(void);
+void editor_notify_file_opened(int index, const char *path, int len);
 
 #endif  // EDITOR_H_

--- a/src/synctex.c
+++ b/src/synctex.c
@@ -290,6 +290,7 @@ static void synctex_process_line(fz_context *ctx, synctex_t *stx, int offset, co
         myabort();
       }
       ib_append(ctx, &stx->input_off, offset);
+      editor_notify_file_opened(index, (const char *)bol, eol - bol);
       break;
     }
 


### PR DESCRIPTION
This PR was inspired by https://github.com/DominikPeters/texpresso-vscode/issues/1.

TeXpresso now emits an input-file message when a file is being read:
- sexp: `(input-file 123 "foo.tex")`
- json: `["input-file", 123, "foo.tex"]`

The integer is a unique, monotonous index.
When a new line is produced with a lower index, it means that the process backtracked and all files with a higher are no longer monitored. (Though this is very likely to be temporary, if installing watchers is expensive, it is better to batch the changes and update the editor state from time to time).

The paths are printed relative to the root file. They might be non-existent on the file-system (for instance if they exist only in TeXpresso's overlay, that is the case for the intermediate files produced by beamer), so users should not make assumpations and validate the path themselves.

Right now it hooks into SyncTeX to track files:
- only text files are tracked (not graphics)
- the indices printed are the SyncTex input indices; they should be attributed no other meaning than being monotonic and useful to detect backtracking occurrences
- disabling SyncTeX will disable the feature... but why would one disable SyncTeX

I might revisit the idea later, consider this a draft.