### PR TITLE
Fix a crash when there is a race between edition and TeX processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Workaround limitations of fork on macOS when using system fonts
 - Up/down scrolls vertically through the document, and change pages when reaching the border (#52, contributed by @gasche)
 - Fix JSON printing of non-ASCII characters (broke paths with chinese characters, see #53)
+- Fix a crash due to a broken invariant when the contents being edited has been read by the TeX worker but the driver is not aware
 
 # v0.0 Fri Apr  5 06:52:52 JST 2024
 

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -1276,10 +1276,12 @@ static void rollback_add_change(fz_context *ctx, struct tex_engine *self, fileen
   if (trace_len == NOT_IN_TRANSACTION)
     mabort();
 
-  if (e->seen < changed)
+  if (e->seen < changed && trace_len == get_process(self)->trace_len)
   {
     if (process_pending_messages(ctx, self))
       return;
+
+    trace_len = self->rollback.trace_len = get_process(self)->trace_len;
 
     // A pending message might have updated e->seen
     if (e->seen < changed)

--- a/src/engine_tex.c
+++ b/src/engine_tex.c
@@ -1197,6 +1197,7 @@ static bool rollback_end(fz_context *ctx, struct tex_engine *self, int *tracep, 
       return false;
     }
     trace_len -= 1;
+    revert_trace(&self->trace[trace_len]);
     if (trace_len > 0)
       self->rollback.offset = self->trace[trace_len].seen;
   }


### PR DESCRIPTION
These are tentative fixes for bug that caused a complete crash or a de-synchronization.
I will try this branch for a few days to see if it really addresses the bugs.

During processing, the driver has to keep track of the contents read by the TeX worker.
To keep the overhead low, the worker does not systematically which bytes it is processing, but only on specific events.
Therefore, the driver might be a few milliseconds/a few bytes behind what was actually been processed.

A problem occurs when the content edited is in the range that has not yet been communicated. The driver has to explicitly synchronize with the worker to lift any uncertainty.
A few outcomes are possible:
- the synchronization succeeds and:
  - the affected contents has not been observed: nothing needs to be done
  - the affected contents has been observed: need to rollback
  - the document finished processing (the worker exited): need to cleanup the process and rollback
- the synchronization fails (time out): this might be because the worker is stuck in an infinite loop; we already wasted 10ms (or whatever the threshold), to remain interactive there is not time to waste: we kill the process and force a rollback.

1) The crash

In the rollback case and if there was no other changes, the rollback code did not properly undo the last read.
This is a problem if it is the only read recorded in the file being changed: in this case, the code would enter an infinite loop trying to rollback before the read, and would end up reading outside of the rollback buffer.

2) The desynchronization

If the synchronization succeeds and there are other changes, the updates due to the synchronization itself was not properly reverted.

**This is really spaghetti code with concurrent processes, I need to clean that at some point in the future.**