### PR TITLE
Remove dependency on re2c for normal build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ distclean:
 	rm -rf build Makefile.config
 	cd tectonic && cargo clean
 
+re2c:
+	$(MAKE) -C src $@
+
 UNAME := $(shell uname)
 
 Makefile.config: Makefile
@@ -52,4 +55,4 @@ texpresso-tonic:
 	$(MAKE) -f Makefile.tectonic tectonic
 	cp -f tectonic/target/release/texpresso-tonic build/
 
-.PHONY: all dev clean config texpresso-tonic
+.PHONY: all dev clean config texpresso-tonic re2c

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,9 @@ texpresso-debug: $(BUILD)/texpresso-debug
 $(BUILD)/texpresso-debug: ../scripts/texpresso-debug
 	cp $< $@
 
+re2c:
+	$(MAKE) -C dvi $@
+
 $(DIR)/%.o: %.c
 	$(CC) -c -o $@ -Idvi/ $<
 
@@ -44,4 +47,4 @@ clean:
 	$(MAKE) -C .. config
 include ../Makefile.config
 
-.PHONY: all clean $(TARGETS)
+.PHONY: all clean $(TARGETS) re2c

--- a/src/dvi/Makefile
+++ b/src/dvi/Makefile
@@ -17,19 +17,25 @@ $(DIR)/libmydvi.a: $(DIR_OBJECTS)
 $(DIR)/dvi_resmanager.o: dvi_resmanager.c
 	$(CC) $(shell pkg-config --cflags freetype2) -c -o $@ $<
 
-%.c: %.re2c.c
-	re2c $< -o $@ --tags --bit-vectors
-
 $(DIR)/%.o: %.c
 	$(CC) -c -o $@ $<
 
 $(DIR)/%.o: $(DIR)/%.c
 	$(CC) -c -o $@ $<
 
+%.c: %.re2c.c
+	@ if test $@ -ot $^; then \
+		echo -e >&2 "\033[0;33mre2c: $@ is older than $^ or missing"; \
+	  echo -e >&2 "      consider running 'make re2c'\033[0m"; \
+	fi
+
+re2c:
+	$(MAKE) -f Makefile.re2c all
+
 clean:
 	rm -f $(DIR)/libmydvi.a $(DIR_OBJECTS)
 
-.PHONY: all clean
+.PHONY: all clean re2c
 
 ../../Makefile.config:
 	$(MAKE) -C ../.. config

--- a/src/dvi/Makefile.re2c
+++ b/src/dvi/Makefile.re2c
@@ -1,0 +1,9 @@
+SOURCES = $(wildcard *.re2c.c)
+TARGETS = $(patsubst %.re2c.c,%.c,$(SOURCES))
+
+all: $(TARGETS)
+
+%.c: %.re2c.c
+	re2c $< -o $@ --tags --bit-vectors
+
+.PHONY: all


### PR DESCRIPTION
Even though the re2c generated source file is committed to the repository, the Makefile is a bit too sensitive and tries to rebuild it (after a fresh check-out , the files should have the same mtime).

Only emit a warning message and add an explicit `make re2c` target for updating the generated files.