### PR TITLE
Small fixes / QoL improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@
 - Workaround limitations of fork on macOS when using system fonts
 - Up/down scrolls vertically through the document, and change pages when reaching the border (#52, contributed by @gasche)
 - Fix JSON printing of non-ASCII characters (broke paths with chinese characters, see #53)
-- Fix a crash due to a broken invariant when the contents being edited has been read by the TeX worker but the driver is not aware
+- Fix a crash due to a broken invariant when the contents being edited has been read by the TeX worker but the driver is not aware (#62)
+- Don't require re2c for a non-developer build (#64)
+- Load local font/resources files from filesystem
+- Remove gumbo dependencies on macOS (change in homebrew packaging of mupdf)
+- On Linux, try Wayland video driver first to solve HIDPI issues
+- PDF engine: reload document on filesystem changes
 
 # v0.0 Fri Apr  5 06:52:52 JST 2024
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ config:
 	echo >Makefile.config "CFLAGS=-O2 -ggdb -I. -fPIC -I$(BREW)/include"
 	echo >>Makefile.config 'CC=gcc $$(CFLAGS)'
 	echo >>Makefile.config 'LDCC=g++ $$(CFLAGS)'
-	echo >>Makefile.config "LIBS=-L$(BREW)/lib -lmupdf -lm `CC=gcc ./mupdf-config.sh -L$(BREW)/lib` -lz -ljpeg -ljbig2dec -lharfbuzz -lfreetype -lopenjp2 -lgumbo -lSDL2"
+	echo >>Makefile.config "LIBS=-L$(BREW)/lib -lmupdf -lm `CC=gcc ./mupdf-config.sh -L$(BREW)/lib` -lz -ljpeg -ljbig2dec -lharfbuzz -lfreetype -lopenjp2 -lSDL2"
 	echo >>Makefile.config "TECTONIC_ENV=PKG_CONFIG_PATH=$(BREW_ICU4C)/lib/pkgconfig"
 endif
 

--- a/mupdf-config.sh
+++ b/mupdf-config.sh
@@ -11,16 +11,29 @@ int main(int argc, char **argv)
 }
 END
 
+LINKING=""
+SKIPPING=""
+
 link_if_possible()
 {
   for i in "$@"; do
-    if $CC "$i" $FLAGS -o build/mupdf_test build/mupdf_test.c > /dev/null; then
+    if $CC "$i" $FLAGS -o build/mupdf_test build/mupdf_test.c 2> /dev/null; then
+      LINKING="$LINKING $i"
       printf " %s"  "$i"
+    else
+      SKIPPING="$SKIPPING $i"
     fi
   done
 }
 
-link_if_possible -lmupdf-third -lleptonica -ltesseract -lmujs
+link_if_possible -lmupdf-third -lleptonica -ltesseract -lmujs -lgumbo
+
+if [ -n "$LINKING" ]; then
+  echo >&2 "Linking$LINKING"
+fi
+if [ -n "$SKIPPING" ]; then
+  echo >&2 "Skipping$SKIPPING"
+fi
 
 rm -f build/mupdf_test*
 

--- a/src/driver.c
+++ b/src/driver.c
@@ -225,8 +225,25 @@ int main(int argc, const char **argv)
   fz_context *ctx = fz_new_context(NULL, NULL, FZ_STORE_DEFAULT);
   fz_register_document_handlers(ctx);
 
+  bool init = 0;
+
+#ifndef __APPLE__
+  if (!getenv("SDL_VIDEODRIVER"))
+  {
+    setenv("SDL_VIDEODRIVER", "wayland", 0);
+    if (SDL_Init(SDL_INIT_VIDEO) < 0)
+    {
+      fprintf(stderr, "SDL could not initialize wayland driver! SDL_Error: %s\n", SDL_GetError());
+      fprintf(stderr, "Falling back to default driver\n");
+      unsetenv("SDL_VIDEODRIVER");
+    }
+    else 
+      init = 1;
+  }
+#endif
+
   //Initialize SDL
-  if (SDL_Init(SDL_INIT_VIDEO) < 0)
+  if (init == 0 && SDL_Init(SDL_INIT_VIDEO) < 0)
   {
     fprintf(stderr, "SDL could not initialize! SDL_Error: %s\n", SDL_GetError());
     abort();

--- a/src/dvi/dvi_resmanager.c
+++ b/src/dvi/dvi_resmanager.c
@@ -123,7 +123,7 @@ tectonic_hooks_open_file(fz_context *ctx, void *env, dvi_reskind kind, const cha
       break;
 
     case RES_FONT:
-      if (name[0] == '/')
+      if (name[0] == '/' || name[0] == '.')
       {
         path = (char *)name;
         break;
@@ -359,7 +359,7 @@ bundle_serve_hooks_open_file(fz_context *ctx, void *_env, dvi_reskind kind, cons
       break;
 
     case RES_FONT:
-      if (name[0] == '/')
+      if (name[0] == '/' || name[0] == '.' || fz_file_exists(ctx, name))
       {
         path = (char *)name;
         break;

--- a/src/engine_pdf.c
+++ b/src/engine_pdf.c
@@ -32,6 +32,7 @@ struct pdf_engine
   char *path;
   int page_count;
   fz_document *doc;
+  bool changed;
 };
 
 #define SELF struct pdf_engine *self = (struct pdf_engine*)_self
@@ -71,10 +72,26 @@ static void engine_begin_changes(txp_engine *_self, fz_context *ctx)
 
 static void engine_detect_changes(txp_engine *_self, fz_context *ctx)
 {
+  SELF;
+  fz_document *doc = fz_open_document(ctx, self->path);
+  if (!doc)
+    return;
+
+  fz_drop_document(ctx, self->doc);
+  self->doc = doc;
+  self->page_count = fz_count_pages(ctx, doc);
+  self->changed = 1;
 }
 
 static bool engine_end_changes(txp_engine *_self, fz_context *ctx)
 {
+  SELF;
+  if (self->changed)
+  {
+    self->changed = 0;
+    return 1;
+  }
+  else
   return 0;
 }
 


### PR DESCRIPTION
- Don't require re2c for a non-developer build (#64)
- Load local font/resources files from filesystem
- Remove gumbo dependencies on macOS (change in homebrew packaging of mupdf)
- On Linux, try Wayland video driver first to solve HIDPI issues
- PDF engine: reload document on filesystem changes