### PR TITLE
Add crop & invert command (editor -> texpresso)

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -93,10 +93,6 @@ A few other commands are provided, though they are part of the \txp development 
 
 The window can be manipulated using both keyboard and mouse:
 
-\begin{itemize}
-
-\end{itemize}
-
 \section{Alternatives}
 
 \txp is far from being the first solution to bring interactivity to \LaTeX{} rendering. We tried to collect and compare the existing approaches.

--- a/src/editor.c
+++ b/src/editor.c
@@ -228,6 +228,12 @@ bool editor_parse(fz_context *ctx,
             },
     };
   }
+  else if (strcmp(verb, "crop") == 0)
+  {
+    if (len != 1)
+      goto arity;
+    *out = (struct editor_command){.tag = EDIT_CROP, .crop = {}};
+  }
   else
   {
     fprintf(stderr, "[command] unknown verb: %s\n", verb);

--- a/src/editor.c
+++ b/src/editor.c
@@ -234,6 +234,12 @@ bool editor_parse(fz_context *ctx,
       goto arity;
     *out = (struct editor_command){.tag = EDIT_CROP, .crop = {}};
   }
+  else if (strcmp(verb, "invert") == 0)
+  {
+    if (len != 1)
+      goto arity;
+    *out = (struct editor_command){.tag = EDIT_INVERT, .invert = {}};
+  }
   else
   {
     fprintf(stderr, "[command] unknown verb: %s\n", verb);

--- a/src/editor.h
+++ b/src/editor.h
@@ -24,6 +24,7 @@ enum EDITOR_COMMAND
   EDIT_SYNCTEX_FORWARD,
   EDIT_MAP_WINDOW,
   EDIT_UNMAP_WINDOW,
+  EDIT_CROP,
 };
 
 struct editor_command {
@@ -82,6 +83,8 @@ struct editor_command {
     struct {
     } unmap_window;
 
+    struct {
+    } crop;
   };
 };
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -25,6 +25,7 @@ enum EDITOR_COMMAND
   EDIT_MAP_WINDOW,
   EDIT_UNMAP_WINDOW,
   EDIT_CROP,
+  EDIT_INVERT,
 };
 
 struct editor_command {
@@ -85,6 +86,9 @@ struct editor_command {
 
     struct {
     } crop;
+
+    struct {
+    } invert;
   };
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -973,6 +973,15 @@ static void interpret_command(struct persistent_state *ps,
       }
     }
     break;
+
+    case EDIT_CROP:
+    {
+      txp_renderer_config *config =
+          txp_renderer_get_config(ps->ctx, ui->doc_renderer);
+      config->crop = !config->crop;
+      schedule_event(RENDER_EVENT);
+    }
+    break;
   }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -982,6 +982,14 @@ static void interpret_command(struct persistent_state *ps,
       schedule_event(RENDER_EVENT);
     }
     break;
+    case EDIT_INVERT:
+    {
+      txp_renderer_config *config =
+          txp_renderer_get_config(ps->ctx, ui->doc_renderer);
+      config->invert_color = !config->invert_color;
+      schedule_event(RENDER_EVENT);
+    }
+    break;
   }
 }
 


### PR DESCRIPTION
This allows for cropping and inverting from the editor, instead of only by keybind in texpresso itself.