### PR TITLE
build(tectonic): tectonic building include/lib path on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ config:
 	echo >>Makefile.config 'CC=gcc $$(CFLAGS)'
 	echo >>Makefile.config 'LDCC=g++ $$(CFLAGS)'
 	echo >>Makefile.config "LIBS=-L$(BREW)/lib -lmupdf -lm `CC=gcc ./mupdf-config.sh -L$(BREW)/lib` -lz -ljpeg -ljbig2dec -lharfbuzz -lfreetype -lopenjp2 -lSDL2"
-	echo >>Makefile.config "TECTONIC_ENV=PKG_CONFIG_PATH=$(BREW_ICU4C)/lib/pkgconfig"
+	echo >>Makefile.config "TECTONIC_ENV=PKG_CONFIG_PATH=$(BREW_ICU4C)/lib/pkgconfig C_INCLUDE_PATH=$(BREW_ICU4C)/include LIBRARY_PATH=$(BREW_ICU4C)/lib"
 endif
 
 texpresso-tonic:


### PR DESCRIPTION
- Append `C_INCLUDE_PATH` and `LIBRARY_PATH` whose parent dirs are the same as `PKG_CONFIG_PATH`

In my environment with brew on MacOSX 13.7.4, this change is a workaround for #85. Did not test on other platforms yet.

BTW, I need also to set `--features external-harfbuzz` on my MacOS but I didn't guarantee that works for all so I kept unchanged for `Makefile.tectonic`.