### PR TITLE
Fix: update cargo flags for MacOS

### DIFF
--- a/Makefile.tectonic
+++ b/Makefile.tectonic
@@ -1,7 +1,7 @@
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Darwin)
-CARGO_BUILD_FLAGS ?= --release
+CARGO_BUILD_FLAGS ?= --release --features external-harfbuzz
 endif
 ifeq ($(UNAME), Linux)
 CARGO_BUILD_FLAGS ?= --release --features external-harfbuzz


### PR DESCRIPTION
Hi, 

It seems that `--features external-harfbuzz` cargo flag (mentioned in #89) is required for all macOS users for correct  `texpresso-tonic` build (#65, #84, #85 and #88 had the same crash report as on my Sonoma 14.7.2)

Adding the flag should resolve those issues. 