### PR TITLE
Improve implementation of UTF-16 range support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ texpresso
 compile_commands.json
 Makefile.config
 .DS_Store
+test/test_utf_mapping

--- a/EDITOR-PROTOCOL.md
+++ b/EDITOR-PROTOCOL.md
@@ -80,6 +80,12 @@ Line numbering starts at 0 and line count is defined as the number of '\n'.
 To insert multiple lines, separate them with '\n' in data. Note that if data ends with '\n', it will insert a new empty-line at the end.
 
 ```scheme
+(change-range "path" start-line start-column end-line end-column "replacement-text")
+```
+
+Update file at "path" in VFS (it should have been `open`ed before), by replacing the characters in range starting from line `start-line` at column `start-column` (implemented by counting the number of UTF-16 code units, with 0 being the beginning of the line) up to line `end-line` at column `end-column`. This is designed to be compatible with [LSP position encoding](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#positionEncodingKind) using the default 'utf-16' encoding.
+
+```scheme
 (theme (bg_r bg_g bg_b) (fg_r fg_g fg_b))
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,9 @@ re2c:
 	$(MAKE) -C src $@
 
 test-utfmapping:
-	gcc -g -o test/test_utf_mapping test/test_utf_mapping.c
-	test/test_utf_mapping &> test/test_utf_mapping.output
+	mkdir -p build
+	gcc -g -o build/test_utf_mapping test/test_utf_mapping.c
+	build/test_utf_mapping &> test/test_utf_mapping.output
 	git diff --exit-code test/test_utf_mapping.output
 
 UNAME := $(shell uname)

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ distclean:
 re2c:
 	$(MAKE) -C src $@
 
+test-utfmapping:
+	gcc -g -o test/test_utf_mapping test/test_utf_mapping.c
+	test/test_utf_mapping &> test/test_utf_mapping.output
+	git diff --exit-code test/test_utf_mapping.output
+
 UNAME := $(shell uname)
 
 Makefile.config: Makefile

--- a/src/utf_mapping.h
+++ b/src/utf_mapping.h
@@ -1,0 +1,131 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Move the pointer `start` to an UTF-8 encoded string ending at `end` forward
+// by `count` UTF-16 code units.
+// Return NULL if a fatal error was encountered (invalid encoding or `count`
+// points in the middle of a surrogate pair).
+// LSP ranges
+static const void *move_utf8_by_utf16_codeunits(const void *start,
+                                                const void *end,
+                                                int count)
+{
+  if (start >= end)
+  {
+    if (count == 0)
+      return start;
+    return NULL;
+  }
+
+  const unsigned char *p = start;
+  int warned_continuation = 0;
+
+  while (count > 0)
+  {
+    unsigned char b = *p;
+
+    // 1-byte UTF-8: ASCII char
+    if (b < 0x80)
+    {
+
+      // Error: reached the end of the line
+      if (b == '\n')
+      {
+        fprintf(stderr,
+                "[error] Invalid UTF-16 range: "
+                "pointing past end of line\n");
+        return NULL;
+      }
+
+      // Count as single UTF-16 code unit
+      count -= 1;
+      p += 1;
+
+      // Out of bounds
+      if ((void*)p > end)
+        return NULL;
+    }
+
+    // 1-byte: continuation (warn and ignore)
+    else if (b < 0xC0)
+    {
+      if (!warned_continuation)
+      {
+        fprintf(stderr,
+                "[warning] UTF-16 range: "
+                "unexpected continuation byte\n");
+        warned_continuation = 1;
+      }
+      p += 1;
+    }
+
+    // 2-byte UTF-8, 1 UTF-16 code unit
+    else if (b < 0xE0)
+    {
+      count -= 1;
+      p += 2;
+      if ((void*)p <= end && p[-1] == '\n')
+        goto invalid_nl;
+    }
+
+    // 3-byte UTF-8, 1 UTF-16 code unit
+    else if (b < 0xF0)
+    {
+      count -= 1;
+      p += 3;
+      if ((void*)p <= end && (p[-1] == '\n' || p[-2] == '\n'))
+        goto invalid_nl;
+    }
+
+    // 4-byte UTF-8 encodings: translate to a surrogate pair, needing two
+    // UTF-16 code units
+    else
+    {
+      p += 4;
+      count -= 2;
+      if ((void*)p <= end && (p[-1] == '\n' || p[-2] == '\n' || p[-3] == '\n'))
+        goto invalid_nl;
+    }
+  }
+
+  // At this point, count is:
+  // - exactly 0 if the traversal succeeded
+  // - (-1) if the offset given pointed in the middle of a surrogate pair
+  // - >0 if the offset is pointing past the end of the buffer
+  //
+  if (count > 0 || (void*)p > end)
+  {
+    fprintf(stderr,
+            "[error] Invalid UTF-16 range: "
+            "pointing past end of buffer\n");
+    return NULL;
+  }
+
+  if (count < 0)
+  {
+    fprintf(stderr,
+            "[error] Invalid UTF-16 range: "
+            "pointing in the middle of a surrogate pair\n");
+    return NULL;
+  }
+
+  return p;
+
+invalid_nl:
+  fprintf(stderr,
+          "[error] Broken UTF-8 encoding: "
+          "line return in the middle of a codepoint\n");
+  return NULL;
+}
+
+static int utf16_to_utf8_offset(const void *p, const void *end, size_t utf16_index)
+{
+  const void *p2 = move_utf8_by_utf16_codeunits(p, end, utf16_index);
+
+  if (p2 && p2 <= end)
+    return p2 - p;
+  else
+    return -1;
+}

--- a/test/test_utf_mapping.c
+++ b/test/test_utf_mapping.c
@@ -1,0 +1,130 @@
+#include "../src/utf_mapping.h"
+
+// Test strings covering all corner cases
+struct test_vec {
+  const char *name, *comment, *input;
+} tests[] = {
+    {"test_ascii", "Basic ASCII (1-byte UTF-8, 1 UTF-16 code unit)", "Hello\n"},
+
+    {"test_2byte",
+     "Single 2-byte UTF-8 (é) - valid, should advance 1 UTF-16 unit",
+     "caf\xc3\xa9\n"},
+
+    {"test_3byte",
+     "Single 3-byte UTF-8 (€) - valid, should advance 1 UTF-16 unit",
+     "caf\xe2\x82\xac\n"},
+
+    {"test_4byte",
+     "Single 4-byte UTF-8 (🌈) - valid, should advance 2 UTF-16 units",
+     "caf\xf0\x9f\x8c\x88\n"},
+
+    {"test_mixed", "Mixed: 1-byte + 2-byte + 3-byte + 4-byte",
+     "A\xc3\xa9\xe2\x82\xac\xf0\x9f\x8c\x88\n"},
+
+    {"test_invalid_continuation", "Invalid continuation byte (no leading byte)",
+     "\x80\x81\x82\n"},
+
+    {"test_overlong", "Overlong encoding (e.g., 2-byte for U+0000)",
+     "\xC0\x80\xC1\xBF\n"},
+
+    {"test_surrogate",
+     "Surrogate pair in UTF-8 (invalid, should trigger error, U+D800)",
+     "\xED\xA0\x80\n"},
+
+    {"test_surrogate_pair", "Surrogate pair (U+D800 + U+DFFF)",
+     "\xED\xA0\x80\xED\xAF\xBF\n"},
+
+    {"test_nl_in_middle_2byte",
+     "Line feed in the middle of a codepoint (should fail)",
+     "ca\xE9\n"},  // \xE9 is continuation, but \xE9 alone is invalid
+
+    {"test_nl_in_middle_3byte", "\\xE2\\x82 is incomplete 3-byte",
+     "ca\xE2\x82\n"},
+
+    {"test_nl_in_middle_4byte", "incomplete 4-byte", "ca\xF0\x90\x8C\n"},
+
+    {"test_nl_after_surrogate",
+     "Line feed after partial surrogate pair (high surrogate, then \\n)",
+     "\xED\xA0\n"},
+
+    {"test_trailing_continuation",
+     "Trailing continuation bytes (no leading byte)", "\x80\x81\x82\x83\n"},
+
+    {"test_end_mid_4byte", "incomplete 4-byte", "caf\xc3\xa9\xF0\x90\x8C"},
+
+    {"test_middle_surrogate",
+     "Pointing in middle of surrogate pair "
+     "(should fail, U+D800 not followed by low surrogate)",
+     "\xED\xA0\x80"},
+
+    {NULL, NULL, NULL},
+};
+
+int fails = 0;
+int last_offset = 0;
+
+static void output_marker_at_offset(int offset)
+{
+  if (offset <= last_offset)
+    abort();
+
+  while (offset > last_offset && fails > 0)
+  {
+    putchar('_');
+    last_offset += 1;
+    fails -= 1;
+  }
+  fails = 0;
+
+  while (offset > last_offset)
+  {
+    putchar(' ');
+    last_offset += 1;
+  }
+
+  putchar('^');
+  last_offset += 1;
+}
+
+int main()
+{
+  int counter = 0;
+  for (struct test_vec *test = tests; test->name; test++)
+  {
+    printf("# Test %d. %s: %s\n\n", ++counter, test->name, test->comment);
+
+    int len = strlen(test->input);
+    const unsigned char *input = (void*)test->input;
+    for (int i = 0; i < len; i++)
+    {
+      if (input[i] < 0x80 && input[i] > ' ')
+        printf("| %c  ", input[i]);
+      else
+        printf("| %02X ", input[i]);
+    }
+    printf("|\n");
+
+    fails = 0;
+    last_offset = 0;
+
+    for (int i = 0; i < len; i++)
+    {
+      int count = utf16_to_utf8_offset(test->input, test->input + len, i);
+      if (count == -1)
+        fails += 1;
+      else
+        output_marker_at_offset(count * 5 + 2);
+    }
+
+    while (fails > 0)
+    {
+      putchar('_');
+      fails -= 1;
+    }
+    printf("\n");
+    fflush(NULL);
+    printf("\n");
+  }
+
+  return 0;
+}

--- a/test/test_utf_mapping.output
+++ b/test/test_utf_mapping.output
@@ -1,0 +1,124 @@
+# Test 1. test_ascii: Basic ASCII (1-byte UTF-8, 1 UTF-16 code unit)
+
+| H  | e  | l  | l  | o  | 0A |
+  ^    ^    ^    ^    ^    ^
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 2. test_2byte: Single 2-byte UTF-8 (é) - valid, should advance 1 UTF-16 unit
+
+| c  | a  | f  | C3 | A9 | 0A |
+  ^    ^    ^    ^         ^_
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 3. test_3byte: Single 3-byte UTF-8 (€) - valid, should advance 1 UTF-16 unit
+
+| c  | a  | f  | E2 | 82 | AC | 0A |
+  ^    ^    ^    ^              ^__
+[error] Invalid UTF-16 range: pointing in the middle of a surrogate pair
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 4. test_4byte: Single 4-byte UTF-8 (🌈) - valid, should advance 2 UTF-16 units
+
+| c  | a  | f  | F0 | 9F | 8C | 88 | 0A |
+  ^    ^    ^    ^_                  ^__
+[error] Invalid UTF-16 range: pointing in the middle of a surrogate pair
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 5. test_mixed: Mixed: 1-byte + 2-byte + 3-byte + 4-byte
+
+| A  | C3 | A9 | E2 | 82 | AC | F0 | 9F | 8C | 88 | 0A |
+  ^    ^         ^              ^_                  ^_____
+[warning] UTF-16 range: unexpected continuation byte
+[error] Invalid UTF-16 range: pointing past end of line
+[warning] UTF-16 range: unexpected continuation byte
+[error] Invalid UTF-16 range: pointing past end of line
+[warning] UTF-16 range: unexpected continuation byte
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 6. test_invalid_continuation: Invalid continuation byte (no leading byte)
+
+| 80 | 81 | 82 | 0A |
+  ^___
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 7. test_overlong: Overlong encoding (e.g., 2-byte for U+0000)
+
+| C0 | 80 | C1 | BF | 0A |
+  ^         ^         ^__
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 8. test_surrogate: Surrogate pair in UTF-8 (invalid, should trigger error, U+D800)
+
+| ED | A0 | 80 | 0A |
+  ^              ^__
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 9. test_surrogate_pair: Surrogate pair (U+D800 + U+DFFF)
+
+| ED | A0 | 80 | ED | AF | BF | 0A |
+  ^              ^              ^____
+[error] Invalid UTF-16 range: pointing past end of buffer
+
+# Test 10. test_nl_in_middle_2byte: Line feed in the middle of a codepoint (should fail)
+
+| c  | a  | E9 | 0A |
+  ^    ^    ^_
+[error] Broken UTF-8 encoding: line return in the middle of a codepoint
+[error] Broken UTF-8 encoding: line return in the middle of a codepoint
+
+# Test 11. test_nl_in_middle_3byte: \xE2\x82 is incomplete 3-byte
+
+| c  | a  | E2 | 82 | 0A |
+  ^    ^    ^__
+[error] Broken UTF-8 encoding: line return in the middle of a codepoint
+[error] Broken UTF-8 encoding: line return in the middle of a codepoint
+[error] Broken UTF-8 encoding: line return in the middle of a codepoint
+
+# Test 12. test_nl_in_middle_4byte: incomplete 4-byte
+
+| c  | a  | F0 | 90 | 8C | 0A |
+  ^    ^    ^___
+[error] Broken UTF-8 encoding: line return in the middle of a codepoint
+[error] Broken UTF-8 encoding: line return in the middle of a codepoint
+
+# Test 13. test_nl_after_surrogate: Line feed after partial surrogate pair (high surrogate, then \n)
+
+| ED | A0 | 0A |
+  ^__
+[warning] UTF-16 range: unexpected continuation byte
+[error] Invalid UTF-16 range: pointing past end of line
+[warning] UTF-16 range: unexpected continuation byte
+[error] Invalid UTF-16 range: pointing past end of line
+[warning] UTF-16 range: unexpected continuation byte
+[error] Invalid UTF-16 range: pointing past end of line
+[warning] UTF-16 range: unexpected continuation byte
+[error] Invalid UTF-16 range: pointing past end of line
+
+# Test 14. test_trailing_continuation: Trailing continuation bytes (no leading byte)
+
+| 80 | 81 | 82 | 83 | 0A |
+  ^____
+[error] Invalid UTF-16 range: pointing past end of buffer
+[error] Invalid UTF-16 range: pointing past end of buffer
+
+# Test 15. test_end_mid_4byte: incomplete 4-byte
+
+| c  | a  | f  | C3 | A9 | F0 | 90 | 8C |
+  ^    ^    ^    ^         ^___
+
+# Test 16. test_middle_surrogate: Pointing in middle of surrogate pair (should fail, U+D800 not followed by low surrogate)
+
+| ED | A0 | 80 |
+  ^              ^_
+


### PR DESCRIPTION
This PR complements https://github.com/let-def/texpresso/pull/105:
- document the new `change-range` command
- add and test support for UTF-16 surrogate pairs

@lnay and @DominikPeters: if you have the time, could you test this new implementation?
It would be nice to make sure that:
1. it works at least as nicely as the existing implementation (Zed & VSCode keep working with regular files)
2. Surrogate pairs are properly handled. You can test this by editing a line containing emojis: the document should stay synchronized even when adding characters before or after an emoji.

Getting the emoji to render with XeTeX might be difficult, but what is important is that the text before and after stays correct.
Thanks.