### PR TITLE
Stream mode: Phase 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Run tests – Texpresso
         run: make test-texpresso || echo "fail" > texpresso.status
 
+      - name: Run tests – open-base64
+        run: make test-open-base64 || echo "fail" > open-base64.status
+
       - name: Run tests – TeXpresso with TeX Live
         run: make test-texpresso-texlive || echo "fail" > texpresso-texlive.status
 
@@ -98,6 +101,7 @@ jobs:
           [ ! -f texlive.status ]   && pass=$((pass+1)) || fail=$((fail+1))
           [ ! -f tectonic.status ]  && pass=$((pass+1)) || fail=$((fail+1))
           [ ! -f texpresso.status ] && pass=$((pass+1)) || fail=$((fail+1))
+          [ ! -f open-base64.status ] && pass=$((pass+1)) || fail=$((fail+1))
           [ ! -f texpresso-texlive.status ]  && pass=$((pass+1)) || fail=$((fail+1))
           [ ! -f texpresso-tectonic.status ] && pass=$((pass+1)) || fail=$((fail+1))
           echo "Passed: $pass" >> "$GITHUB_STEP_SUMMARY"

--- a/EDITOR-PROTOCOL.md
+++ b/EDITOR-PROTOCOL.md
@@ -63,6 +63,12 @@ Populate TeXpresso VFS with a file at "path" storing "contents".
 
 
 ```scheme
+(open-base64 "path" "base64-contents")
+```
+
+Populate TeXpresso VFS with a file at "path" transferring binary data in base64 format. TeXpresso decodes "base64-contents" into raw bytes before storing.
+
+```scheme
 (close "path")
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ test-tectonic:
 	build/texpresso-xetex -tectonic test/simple.tex
 	rm simple.aux simple.log simple.xdv
 
+test-open-base64:
+	printf '(open-base64 "test/simple.tex" "%s")\n' "$$(base64 < test/simple.tex | tr -d '\n')" | \
+	SDL_VIDEODRIVER=dummy build/texpresso -test-initialize test/simple.tex
+
 test-texpresso:
 	SDL_VIDEODRIVER=dummy build/texpresso -test-initialize test/simple.tex
 
@@ -100,4 +104,4 @@ test-texpresso-texlive:
 test-texpresso-tectonic:
 	SDL_VIDEODRIVER=dummy build/texpresso -tectonic -test-initialize test/simple.tex
 
-.PHONY: all dev clean config texpresso common texpresso-xetex re2c compile_commands.json fill-tectonic-cache test-texlive test-tectonic test-texpresso
+.PHONY: all dev clean config texpresso common texpresso-xetex re2c compile_commands.json fill-tectonic-cache test-texlive test-tectonic test-texpresso test-open-base64

--- a/src/frontend/base64.h
+++ b/src/frontend/base64.h
@@ -1,0 +1,46 @@
+#ifndef BASE64_H_
+#define BASE64_H_
+
+// Decode base64 in-place. Returns decoded length, or -1 on error.
+static int base64_decode(unsigned char *data, int len)
+{
+  static const unsigned char table[256] = {
+    ['A']=0,  ['B']=1,  ['C']=2,  ['D']=3,  ['E']=4,  ['F']=5,  ['G']=6,
+    ['H']=7,  ['I']=8,  ['J']=9,  ['K']=10, ['L']=11, ['M']=12, ['N']=13,
+    ['O']=14, ['P']=15, ['Q']=16, ['R']=17, ['S']=18, ['T']=19, ['U']=20,
+    ['V']=21, ['W']=22, ['X']=23, ['Y']=24, ['Z']=25,
+    ['a']=26, ['b']=27, ['c']=28, ['d']=29, ['e']=30, ['f']=31, ['g']=32,
+    ['h']=33, ['i']=34, ['j']=35, ['k']=36, ['l']=37, ['m']=38, ['n']=39,
+    ['o']=40, ['p']=41, ['q']=42, ['r']=43, ['s']=44, ['t']=45, ['u']=46,
+    ['v']=47, ['w']=48, ['x']=49, ['y']=50, ['z']=51,
+    ['0']=52, ['1']=53, ['2']=54, ['3']=55, ['4']=56,
+    ['5']=57, ['6']=58, ['7']=59, ['8']=60, ['9']=61,
+    ['+']=62, ['/']=63,
+  };
+
+  // Strip padding
+  while (len > 0 && data[len - 1] == '=')
+    len--;
+
+  int out = 0;
+  int buf = 0, bits = 0;
+  for (int i = 0; i < len; i++)
+  {
+    unsigned char c = data[i];
+    if (c == '\n' || c == '\r' || c == ' ')
+      continue;
+    if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+          (c >= '0' && c <= '9') || c == '+' || c == '/'))
+      return -1;
+    buf = (buf << 6) | table[c];
+    bits += 6;
+    if (bits >= 8)
+    {
+      bits -= 8;
+      data[out++] = (buf >> bits) & 0xFF;
+    }
+  }
+  return out;
+}
+
+#endif // BASE64_H_

--- a/src/frontend/editor.c
+++ b/src/frontend/editor.c
@@ -61,7 +61,7 @@ bool editor_parse(fz_context *ctx,
     return 0;
   }
 
-  if (strcmp(verb, "open") == 0)
+  if (strcmp(verb, "open") == 0 || strcmp(verb, "open-base64") == 0)
   {
     if (len != 3)
       goto arity;
@@ -76,6 +76,7 @@ bool editor_parse(fz_context *ctx,
                 .path = val_string(ctx, stack, path),
                 .data = val_string(ctx, stack, data),
                 .length = val_string_length(ctx, stack, data),
+                .base64 = strcmp(verb, "open-base64") == 0,
             },
 
     };

--- a/src/frontend/editor.h
+++ b/src/frontend/editor.h
@@ -67,6 +67,7 @@ struct editor_command
       const char *path;
       const char *data;
       int length;
+      bool base64;
     } open;
 
     struct {

--- a/src/frontend/main.c
+++ b/src/frontend/main.c
@@ -38,6 +38,7 @@
 #include "vstack.h"
 #include "prot_parser.h"
 #include "editor.h"
+#include "base64.h"
 
 struct persistent_state *pstate;
 
@@ -913,7 +914,23 @@ static void interpret_command(struct persistent_state *ps,
   switch (cmd.tag)
   {
     case EDIT_OPEN:
-      interpret_open(ps, ui, cmd.open.path, cmd.open.data, cmd.open.length);
+      if (cmd.open.base64)
+      {
+        unsigned char *buf = malloc(cmd.open.length);
+        if (!buf) break;
+        memcpy(buf, cmd.open.data, cmd.open.length);
+        int decoded_len = base64_decode(buf, cmd.open.length);
+        if (decoded_len < 0)
+        {
+          fprintf(stderr, "[command] open-base64: invalid base64 data\n");
+          free(buf);
+          break;
+        }
+        interpret_open(ps, ui, cmd.open.path, (const char *)buf, decoded_len);
+        free(buf);
+      }
+      else
+        interpret_open(ps, ui, cmd.open.path, cmd.open.data, cmd.open.length);
       break;
 
     case EDIT_CLOSE:


### PR DESCRIPTION
Closes #120 (phase 2).

## Report

### feat: add open-binary command

*Idea:* Binary files (images via \includegraphics, fonts, etc.) can't be faithfully transmitted through the existing open command as JSON's `\uXXXX` only covers Unicode codepoints and invalid UTF-8 bytes get replaced with `?`.

New `open-binary` command that accepts base64-encoded data. The editor reads a binary file, encodes it to base64 (ASCII-safe), and sends it. `texpresso` decodes it back to raw bytes and feeds them through the existing `interpret_open` path.

Example: 

```
Sexp:  (open-binary "logo.png" "iVBORw0KGgoAAAANSUh...")
JSON:  ["open-binary", "logo.png", "iVBORw0KGgoAAAANSUh..."]
```

Design decisions

- No new `enum` value: reuses `EDIT_OPEN` with a `binary` flag, since the only difference is a decode step before the same `interpret_open` call.
- In-place decode: base64 output is always ≤ input length, so decoding into a copy of the input buffer works without extra allocation logic.
- No new dependencies: the decoder is a self-contained header.
- Encoding is editor-side: `texpresso` only decodes. Editor plugins (Emacs, VS Code, Neovim) are responsible for base64-encoding binary files before sending.

### chore: add CI target

- `make test-open-binary` which base64-encodes `test/simple.tex` and pipes it as an (`open-binary` ...) `sexp` into `texpresso`, exercising the full path end-to-end.

BTW, I am making these reports manually, and I'm curious if they are helpful, or I should tweak something? I think we could add `CONTRIBUTING.md` to the project with defined templates for issues and PRs.