### PR TITLE
tectonic: direct cache access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all:
+all: | Makefile.config
 	$(MAKE) common texpresso texpresso-xetex
 	@echo "# Build succeeded."
 	@echo "# TeXpresso detects package providers (TeXlive or Tectonic) by looking in PATH:"
@@ -17,16 +17,16 @@ all:
 	@echo "#   build/texpresso -texlive test/simple.tex"
 	@echo "#   build/texpresso -tectonic test/simple.tex"
 
-common:
+common: | Makefile.config
 	$(MAKE) -C src/common
 
-texpresso:
+texpresso: | Makefile.config
 	$(MAKE) -C src/frontend texpresso
 
-dev:
+dev: | Makefile.config
 	$(MAKE) -C src texpresso-dev
 
-debug:
+debug: | Makefile.config
 	$(MAKE) -C src texpresso-debug texpresso-debug-proxy
 
 clean:

--- a/src/common/tectonic_provider.c
+++ b/src/common/tectonic_provider.c
@@ -330,7 +330,14 @@ static void tt15_append_buffer(const char *buffer, size_t len)
 {
   size_t new_len = tt_index.len + len;
   dynbuf_ensure_capacity(&tt_index, new_len);
-  memcpy(tt_index.data + tt_index.len, buffer, len);
+  char *data = tt_index.data + tt_index.len;
+  for (size_t i = 0; i < len; i++)
+  {
+    if (buffer[i] == '\n')
+      data[i] = '\0';
+    else
+      data[i] = buffer[i];
+  }
   tt_index.len += len;
 }
 
@@ -406,11 +413,6 @@ static bool tt15_list_tectonic_files(void)
   if (ferror(f))
     perror("fread/popen");
   pclose(f);
-
-  int count = 0;
-  for (size_t i = 0; i < tt_index.len; i++)
-    if (tt_index.data[i] == '\n')
-      count++;
 
   build_hash_table();
   tt15_prepare_cache();

--- a/src/common/tectonic_provider.c
+++ b/src/common/tectonic_provider.c
@@ -6,344 +6,354 @@
 #include <string.h>
 #include <unistd.h>
 
-int *entries;
+#define READ_BUF_SIZE 4096
+#define READ_HASH_SIZE 128
+#define TECTONIC_PATH_MAX 4096
+#define TECTONIC_CMD_MAX 1024
+
+/* -------------------------------------------------------------------------- */
+/* Global State (Dynamic buffers for index, dirs, entries)                    */
+/* -------------------------------------------------------------------------- */
+
+int *entries = NULL;
 int entries_pow = 1;
+int entries_cap = 1;
 
-char *tt_index = NULL;
-size_t tt_index_len = 0, tt_index_cap = 1;
-bool tt_index_skip = 0;
-bool tt_is_v15 = 0;
+struct dynbuf
+{
+  char *data;
+  size_t len;
+  size_t cap;
+} tt_index = {0, .cap = 1}, tt_dirs = {.cap = 1};
 
-static unsigned long sdbm_hash(const void *p)
+bool tt_index_skip = false;
+bool tt_is_v15 = false;
+
+/* Static buffers for paths, commands, and cache dir */
+static char g_path_buf[TECTONIC_PATH_MAX];
+static char tectonic_cache_dir[TECTONIC_PATH_MAX] = {0};
+static bool tectonic_cache_init = false;
+
+static void dynbuf_ensure_capacity(struct dynbuf *buf, size_t cap)
+{
+  if (cap < buf->cap)
+    return;
+  while (cap >= buf->cap)
+    buf->cap *= 2;
+  char *tmp = realloc(buf->data, buf->cap);
+  if (!tmp)
+    do_abortf("tectonic provider: cannot allocate dynamic buffer");
+  buf->data = tmp;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Hash Table Utilities                                                       */
+/* -------------------------------------------------------------------------- */
+
+static unsigned long sdbm_hash(const char *p)
 {
   unsigned long hash = 0;
   int c;
-
-  for (const unsigned char *str = p; (c = *str); str++)
+  for (const unsigned char *str = (const unsigned char *)p; (c = *str); str++)
     hash = c + (hash << 6) + (hash << 16) - hash;
-
   return hash * 2654435761;
 }
 
-int lookup_entry_index(const char *name)
+static int lookup_entry_index(const char *name)
 {
   unsigned long hash = sdbm_hash(name);
   int mask = (1 << entries_pow) - 1;
   int index = hash & mask;
-
   while (1)
   {
     int offset = entries[index];
     if (offset == -1)
       return index;
-    if (strcmp(name, tt_index + offset) == 0)
+    if (strcmp(name, tt_index.data + offset) == 0)
       return index;
     index = (index + 1) & mask;
   }
 }
 
-static const char *tectonic_user_cache_path(const char *suffixes[])
+static void build_hash_table(void)
 {
-  static char dir[4096] = {0,}, *ptr = NULL;
-  static bool init = 0;
+  int count = 0;
+  for (size_t i = 0; i < tt_index.len; i++)
+    if (tt_index.data[i] == '\0')
+      count++;
 
-  if (!init)
+  int min_cap = count * 4 / 3;
+  while ((1 << entries_pow) <= min_cap)
+    entries_pow++;
+  entries_cap = 1 << entries_pow;
+
+  entries = realloc(entries, entries_cap * sizeof(int));
+  if (!entries)
+    do_abortf("Cannot allocate table for indexing Tectonic bundle.");
+  memset(entries, -1, entries_cap * sizeof(int));
+
+  for (size_t i = 0, j = 0; j < tt_index.len; j++)
   {
-    init = 1;
+    if (tt_index.data[j] != '\0')
+      continue;
+    if (i != j)
+    {
+      int index = lookup_entry_index(tt_index.data + i);
+      if (entries[index] == -1)
+        entries[index] = (int)i;
+      else
+        fprintf(stderr, "tectonic bundle: duplicate entry (%s)\n",
+                tt_index.data + i);
+    }
+    i = j + 1;
+  }
 
+  fprintf(stderr, "tectonic bundle: indexing succeeded (%d entries)\n", count);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Path Building (Macro + Static Buffer Mutation)                             */
+/* -------------------------------------------------------------------------- */
+
+static const char *tectonic_user_cache_path_impl(const char *suffixes[])
+{
+  if (!tectonic_cache_init)
+  {
+    tectonic_cache_init = true;
     FILE *p = popen("tectonic -X show user-cache-dir", "r");
-
-    // Tectonic not found
     if (!p)
     {
       fprintf(stderr, "tectonic: not found\n");
-      return 0;
+      return NULL;
     }
-
-    size_t n = fread(dir, 1, sizeof(dir) - 1, p);
-
-    if (n > 0 && dir[n-1] == '\n')
+    size_t n = fread(tectonic_cache_dir, 1, sizeof(tectonic_cache_dir) - 1, p);
+    pclose(p);
+    if (n > 0 && tectonic_cache_dir[n - 1] == '\n')
     {
       n--;
-      dir[n] = 0;
-      ptr = dir + n;
-      fprintf(stderr, "tectonic: cache directory is %s\n", dir);
+      tectonic_cache_dir[n] = '\0';
+      fprintf(stderr, "tectonic: cache directory is %s\n", tectonic_cache_dir);
     }
     else
-      fprintf(stderr, "tectonic provider: malformed cache path: \"%s\"\n", dir);
-  }
-
-  if (!ptr)
-    return NULL;
-
-  if (suffixes)
-  {
-    char *p = ptr;
-    while (*suffixes)
     {
-      p = stpcpy(p, *suffixes);
-      suffixes++;
+      fprintf(stderr, "tectonic provider: malformed cache path\n");
+      return NULL;
     }
   }
-  return dir;
+
+  char *ptr = stpcpy(g_path_buf, tectonic_cache_dir);
+  for (const char **s = suffixes; *s; s++)
+    ptr = stpcpy(ptr, *s);
+  return g_path_buf;
 }
-#define tectonic_user_cache_path(...) tectonic_user_cache_path((const char *[]){__VA_ARGS__ __VA_OPT__(,) NULL})
 
-/* Tectonic 0.16 support */
+#define tectonic_user_cache_path(...) \
+  tectonic_user_cache_path_impl(      \
+      (const char *[]){__VA_ARGS__ __VA_OPT__(, ) NULL})
 
-char *tt_dirs = NULL;
-size_t tt_dirs_len = 0, tt_dirs_cap = 1;
+/* -------------------------------------------------------------------------- */
+/* Shell Quoting & Command Building (Allocation-Free)                         */
+/* -------------------------------------------------------------------------- */
 
-static void tt16_add_dir(char *name)
+static void shell_quote(char *buf, const char *name)
+{
+  *buf++ = '\'';
+  while (*name)
+  {
+    if (*name == '\'')
+    {
+      *buf++ = '\\';
+      *buf++ = '\'';
+      *buf++ = '\'';
+    }
+    else
+    {
+      *buf++ = *name;
+    }
+    name++;
+  }
+  *buf++ = '\'';
+  *buf = '\0';
+}
+
+static const char *build_cat_cmd(const char *name, bool to_stdout)
+{
+  static char buf[TECTONIC_CMD_MAX];
+  char *p = stpcpy(buf, to_stdout ? "tectonic -X bundle cat "
+                                  : ">/dev/null tectonic -X bundle cat ");
+  shell_quote(p, name);
+  return buf;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tectonic 0.16 Support                                                      */
+/* -------------------------------------------------------------------------- */
+
+static void tt16_add_dir(const char *name)
 {
   size_t name_len = strlen(name) + 1;
-  size_t new_len = tt_dirs_len + name_len;
-  if (new_len >= tt_dirs_cap)
-  {
-    while (new_len >= tt_dirs_cap)
-      tt_dirs_cap *= 2;
-    tt_dirs = realloc(tt_dirs, tt_dirs_cap);
-    if (tt_dirs == NULL)
-      do_abortf("tectonic provider: cannot allocate buffer to store bundle directory");
-  }
-
-  memmove(tt_dirs + tt_dirs_len, name, name_len);
-  tt_dirs_len = new_len;
+  size_t new_len = tt_dirs.len + name_len;
+  dynbuf_ensure_capacity(&tt_dirs, new_len);
+  memcpy(tt_dirs.data + tt_dirs.len, name, name_len);
+  tt_dirs.len = new_len;
 }
 
-static void tt16_add_to_index(char *buffer, int len)
+static void tt16_add_to_index(const char *buffer, size_t len)
 {
-  size_t new_cap = tt_index_len + len;
-  if (new_cap >= tt_index_cap)
-  {
-    while (new_cap >= tt_index_cap)
-      tt_index_cap *= 2;
-    tt_index = realloc(tt_index, tt_index_cap);
-    if (tt_index == NULL)
-      do_abortf("tectonic provider: cannot allocate buffer to read bundle index");
-  }
-
-  for (int i = 0; i < len; i++)
+  size_t new_cap = tt_index.len + len;
+  dynbuf_ensure_capacity(&tt_index, new_cap);
+  for (size_t i = 0; i < len; i++)
   {
     if (tt_index_skip)
     {
       if (buffer[i] == '\n')
-        tt_index_skip = 0;
+        tt_index_skip = false;
     }
     else
     {
       if (buffer[i] == ' ' || buffer[i] == '\n')
       {
-        tt_index_skip = 1;
-        tt_index[tt_index_len++] = '\0';
+        tt_index_skip = true;
+        tt_index.data[tt_index.len++] = '\0';
       }
       else
-        tt_index[tt_index_len++] = buffer[i];
+      {
+        tt_index.data[tt_index.len++] = buffer[i];
+      }
     }
   }
-}
-
-static void tt16_load_index_file(const char *path)
-{
-  FILE *f = fopen(path, "r");
-  if (!f)
-  {
-    fprintf(stderr, "tectonic provider: cannot read index file %s\n", path);
-    return;
-  }
-
-  bool skip = false;
-  char buffer[4096];
-  ssize_t read;
-
-  while ((read = fread(buffer, 1, 4096, f)) > 0)
-    tt16_add_to_index(buffer, read);
-
-  if (ferror(f))
-    perror("fread");
-
-  fclose(f);
 }
 
 static void tt16_load_indexes(void)
 {
   const char *data_dir = tectonic_user_cache_path("/data/");
-  DIR *dirp = NULL;
-
-  if (!data_dir || !(dirp = opendir(data_dir)))
+  if (!data_dir)
     return;
 
-  // We found the data directory, load all .index files
-  struct dirent *entry;
-  const char *suffix = ".index";
-  size_t suffix_len = strlen(suffix);
+  DIR *dirp = opendir(data_dir);
+  if (!dirp)
+    return;
 
+  struct dirent *entry;
   while ((entry = readdir(dirp)) != NULL)
   {
     if (entry->d_type == DT_DIR)
+    {
       tt16_add_dir(entry->d_name);
+    }
     else if (entry->d_type == DT_REG)
     {
       size_t name_len = strlen(entry->d_name);
-      if (name_len >= suffix_len &&
-          strcmp(entry->d_name + (name_len - suffix_len), suffix) == 0)
-        tt16_load_index_file(tectonic_user_cache_path("/data/", entry->d_name));
+      if (name_len >= 6 && strcmp(entry->d_name + name_len - 6, ".index") == 0)
+      {
+        const char *idx_path =
+            tectonic_user_cache_path("/data/", entry->d_name);
+        FILE *f = fopen(idx_path, "r");
+        if (f)
+        {
+          char buf[READ_BUF_SIZE];
+          ssize_t n;
+          while ((n = fread(buf, 1, READ_BUF_SIZE, f)) > 0)
+            tt16_add_to_index(buf, n);
+          fclose(f);
+        }
+        else
+        {
+          fprintf(stderr, "tectonic provider: cannot read index file %s\n",
+                  idx_path);
+        }
+      }
     }
   }
-
   closedir(dirp);
 }
 
 static bool tt16_list_tectonic_files(void)
 {
   tt16_load_indexes();
-
-  if (tt_index_len == 0)
+  if (tt_index.len == 0)
   {
     fprintf(stderr,
             "Cannot find Tectonic bundle(s) manifests. Trying to initialize "
             "tectonic now.\n");
-    system("tectonic -X bundle cat SHA256SUM");
+    system("tectonic -X bundle cat SHA256SUM >/dev/null");
     tt16_load_indexes();
   }
-  if (tt_index_len == 0)
+  if (tt_index.len == 0)
     return false;
 
-  // Count number of entries
-  int count = 0;
-  for (int i = 0; i < tt_index_len; i++)
-    if (tt_index[i] == '\0')
-      count += 1;
-
-  // Allocate hashtable for indexing lines
-  int min_cap = count * 4 / 3;
-  while ((1 << entries_pow) <= min_cap)
-    entries_pow++;
-  entries = malloc((1 << entries_pow) * sizeof(*entries));
-  if (entries == NULL)
-    do_abortf("Cannot allocate table for indexing Tectonic bundle.");
-  for (int i = 0; i < (1 << entries_pow); i++)
-    entries[i] = -1;
-
-  // Populate table
-  for (int i = 0, j = 0; j < tt_index_len; j++)
-  {
-    if (tt_index[j] != '\0')
-      continue;
-
-    if (i != j)
-    {
-      int index = lookup_entry_index(tt_index + i);
-      if (entries[index] == -1)
-        entries[index] = i;
-      else
-        fprintf(stderr, "tectonic bundle: duplicate entry (%s)\n",
-                tt_index + i);
-    }
-    i = j + 1;
-  }
-
-  fprintf(stderr, "tectonic bundle: indexing succeeded (%d entries)\n", count);
+  build_hash_table();
   return true;
 }
 
 static const char *tt16_get_file_path(const char *name)
 {
-  for (const char *dir = tt_dirs; dir < tt_dirs + tt_dirs_len; dir = dir + strlen(dir) + 1)
+  static char result_path[TECTONIC_PATH_MAX];
+  for (const char *dir = tt_dirs.data, *end = dir + tt_dirs.len; dir < end;
+       dir += strlen(dir) + 1)
   {
     const char *path = tectonic_user_cache_path("/data/", dir, "/", name);
-    if (access(path, R_OK) == 0)
-      return path;
+    if (access(path, R_OK) != 0)
+      continue;
+    strcpy(result_path, path);
+    return result_path;
   }
 
-  fprintf(stderr, "tectonic provider: %s missing, trying to fetch with tectonic\n", name);
+  fprintf(stderr,
+          "tectonic provider: %s missing, trying to fetch with tectonic\n",
+          name);
 
-  {
-    char command[1024] = ">/dev/null tectonic -X bundle cat ";
-    char *p = command;
-    const char *pname = name;
+  int retcode = system(build_cat_cmd(name, false));
+  if (retcode != 0)
+    fprintf(stderr, "tectonic provider: command returned code %d\n", retcode);
 
-    while (*p)
-      p++;
-
-    *p++ = '\'';
-    while (*pname)
-    {
-      if ((*p++ = *pname++) != '\'')
-        continue;
-      *p++ = '\\';
-      *p++ = '\'';
-      *p++ = '\'';
-    }
-    *p++ = '\'';
-    *p = '\0';
-
-    int retcode = system(command);
-    if (retcode != 0)
-      fprintf(stderr, "tectonic provider: \"%s\" returned code %d\n", command,
-              retcode);
-  }
-
-  for (const char *dir = tt_dirs; dir < tt_dirs + tt_dirs_len; dir = dir + strlen(dir) + 1)
+  for (const char *dir = tt_dirs.data, *end = dir + tt_dirs.len; dir < end;
+       dir += strlen(dir) + 1)
   {
     const char *path = tectonic_user_cache_path("/data/", dir, "/", name);
-    if (access(path, R_OK) == 0)
-    {
-      fprintf(stderr, "tectonic provider: found %s\n", path);
-      return path;
-    }
+    if (access(path, R_OK) != 0)
+      continue;
+    strcpy(result_path, path);
+    fprintf(stderr, "tectonic provider: found %s\n", result_path);
+    return result_path;
   }
 
   do_abortf("tectonic provider: cannot load %s, skipping\n", name);
   return NULL;
 }
 
-/* Tectonic old versions support */
+/* -------------------------------------------------------------------------- */
+/* Tectonic 0.15 Support                                                      */
+/* -------------------------------------------------------------------------- */
 
-static void tt15_append_buffer(char *buffer, int len)
+static void tt15_append_buffer(const char *buffer, size_t len)
 {
-  size_t new_len = tt_index_len + len;
-  if (new_len > tt_index_cap)
-  {
-    while (new_len > tt_index_cap)
-      tt_index_cap *= 2;
-    tt_index = realloc(tt_index, tt_index_cap);
-    if (tt_index == NULL)
-      do_abortf("Cannot allocate buffer to read Tectonic bundle");
-  }
-  memmove(tt_index + tt_index_len, buffer, len);
-  tt_index_len += len;
+  size_t new_len = tt_index.len + len;
+  dynbuf_ensure_capacity(&tt_index, new_len);
+  memcpy(tt_index.data + tt_index.len, buffer, len);
+  tt_index.len += len;
 }
 
 static bool tt15_check_cache_validity(void)
 {
   const char *dir = cache_path("tectonic", "SHA256SUM");
-
-  // Give up if there is no cache directory
   if (!dir)
-    return 0;
+    return false;
 
-  FILE *f;
-
-  // Check version of our cache
-  f = fopen(dir, "rb");
-  // No SHA256SUM: cache is either uninitialized or damaged
+  FILE *f = fopen(dir, "rb");
   if (!f)
-    return 0;
+    return false;
 
-  char b1[4096];
-  int r1 = fread(b1, 1, 4096, f);
+  char b1[READ_HASH_SIZE];
+  size_t r1 = fread(b1, 1, READ_HASH_SIZE, f);
   fclose(f);
 
-  // Compare tectonic SHA256SUM and ours
   FILE *p = popen("tectonic -X bundle cat SHA256SUM", "r");
-  // No tectonic: we cannot check cache :/
   if (!p)
-    return 0;
+    return false;
 
-  char b2[4096];
-  int r2 = fread(b2, 1, 4096, p);
-  b2[r2] = 0;
+  char b2[READ_HASH_SIZE];
+  size_t r2 = fread(b2, 1, READ_HASH_SIZE, p);
   pclose(p);
 
   return (r1 == r2) && (memcmp(b1, b2, r1) == 0);
@@ -354,19 +364,19 @@ static void tt15_prepare_cache(void)
   if (tt15_check_cache_validity())
     return;
 
-  // Base cache directory
   const char *path = cache_path("tectonic", NULL);
+  if (!path)
+    return;
 
-  DIR *dir;
-  struct dirent *entry;
-  char filePath[1024];
-
-  if ((dir = opendir(path)) == NULL)
+  DIR *dir = opendir(path);
+  if (!dir)
   {
     perror("opendir");
     return;
   }
 
+  struct dirent *entry;
+  char filePath[TECTONIC_PATH_MAX];
   while ((entry = readdir(dir)) != NULL)
   {
     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
@@ -375,95 +385,45 @@ static void tt15_prepare_cache(void)
     if (unlink(filePath) != 0)
       perror("unlink");
   }
-
   closedir(dir);
 
   FILE *f = tectonic_get_file("SHA256SUM");
-  if (f) fclose(f);
+  if (f)
+    fclose(f);
 }
 
 static bool tt15_list_tectonic_files(void)
 {
-  // Read the list of all files
   FILE *f = popen("tectonic -X bundle search", "r");
-  if (f == NULL)
+  if (!f)
     do_abortf("Failed to execute 'tectonic -X bundle search'");
 
-  char buffer[4096];
-  ssize_t read;
-  while ((read = fread(buffer, 1, 4096, f)) > 0)
-    tt15_append_buffer(buffer, read);
+  char buffer[READ_HASH_SIZE];
+  ssize_t n;
+  while ((n = fread(buffer, 1, READ_HASH_SIZE, f)) > 0)
+    tt15_append_buffer(buffer, n);
 
   if (ferror(f))
     perror("fread/popen");
-
   pclose(f);
 
-  // Count number of lines
   int count = 0;
-  for (int i = 0; i < tt_index_len; i++)
-    if (tt_index[i] == '\n')
-      count += 1;
+  for (size_t i = 0; i < tt_index.len; i++)
+    if (tt_index.data[i] == '\n')
+      count++;
 
-  // Allocate hashtable for indexing lines
-  int min_cap = count * 4 / 3;
-  while ((1 << entries_pow) <= min_cap)
-    entries_pow++;
-  entries = malloc((1 << entries_pow) * sizeof(*entries));
-  if (entries == NULL)
-    do_abortf("Cannot allocate table for indexing Tectonic bundle.");
-  for (int i = 0; i < (1 << entries_pow); i++)
-    entries[i] = -1;
-
-  // Populate table
-  for (int i = 0, j = 0; j < tt_index_len; j++)
-  {
-    if (tt_index[j] == '\n')
-    {
-      tt_index[j] = '\0';
-      int index = lookup_entry_index(tt_index + i);
-      if (entries[index] == -1)
-        entries[index] = i;
-      else
-        fprintf(stderr, "tectonic bundle: duplicate entry (%s)\n", tt_index + i);
-      i = j + 1;
-    }
-  }
-
-  fprintf(stderr, "tectonic bundle: indexing succeeded (%d entries)\n", count);
+  build_hash_table();
   tt15_prepare_cache();
-
-  return tt_index_len > 0;
+  return tt_index.len > 0;
 }
 
 static FILE *tt15_cat(const char *name)
 {
-  if (!tectonic_has_file(name))
-    return NULL;
-  char buffer[1024] = "tectonic -X bundle cat ", *p = buffer;
-  while (*p)
-    p++;
-
-  *p++ = '\'';
-  while (*name)
-  {
-    if ((*p++ = *name++) != '\'')
-      continue;
-    *p++ = '\\';
-    *p++ = '\'';
-    *p++ = '\'';
-  }
-  *p++ = '\'';
-  *p = '\0';
-
-  return popen(buffer, "r");
+  return popen(build_cat_cmd(name, true), "r");
 }
 
 static const char *tt15_get_file_path(const char *name)
 {
-  if (!tectonic_has_file(name))
-    return NULL;
-
   const char *cached = cache_path("tectonic", name);
   if (access(cached, R_OK) == 0)
     return cached;
@@ -474,69 +434,65 @@ static const char *tt15_get_file_path(const char *name)
 
   FILE *p = tt15_cat(name);
   if (!p)
-    return NULL;
-
-  char buffer[4096];
-  int read;
-  while ((read = fread(buffer, 1, 4096, p)) > 0)
   {
-    if (fwrite(buffer, 1, read, f) != read)
+    fclose(f);
+    return NULL;
+  }
+
+  char buffer[READ_BUF_SIZE];
+  ssize_t n;
+  while ((n = fread(buffer, 1, READ_BUF_SIZE, p)) > 0)
+  {
+    if (fwrite(buffer, 1, n, f) != (size_t)n)
       break;
   }
 
-  bool error = read != 0 || ferror(p) || ferror(f);
+  bool error = (n != 0) || ferror(p) || ferror(f);
   pclose(p);
   fclose(f);
+
   if (error)
   {
     unlink(cached);
     return NULL;
   }
-
   return cached;
 }
 
-/* Version dispatch functions */
+/* -------------------------------------------------------------------------- */
+/* Version Dispatch & Public API                                              */
+/* -------------------------------------------------------------------------- */
+
+static bool list_tectonic_files(void)
+{
+  static bool loaded = false, result = false;
+  if (loaded)
+    return false;
+  loaded = true;
+
+  if (tt16_list_tectonic_files())
+    return (result = true);
+  tt_is_v15 = true;
+  if (tt15_list_tectonic_files())
+    return (result = true);
+
+  return false;
+}
 
 const char *tectonic_get_file_path(const char *name)
 {
   if (!tectonic_has_file(name))
     return NULL;
-
-  return tt_is_v15 ? tt15_get_file_path(name) : tt16_get_file_path(name);
+  else if (tt_is_v15)
+    return tt15_get_file_path(name);
+  else
+    return tt16_get_file_path(name);
 }
-
-static void list_tectonic_files(void)
-{
-  static int loaded = 0;
-  if (loaded)
-    return;
-  loaded = 1;
-
-  if (tt16_list_tectonic_files())
-    return;
-
-  tt_is_v15 = 1;
-  if (tt15_list_tectonic_files())
-    return;
-
-  // No manifest... Tectonic was not initialized?
-  fprintf(stderr,
-          "Cannot find Tectonic bundle(s) manifests.\n"
-          "Please compile a document with tectonic before launching "
-          "TeXpresso.\n");
-  exit(1);
-}
-
-/* Generic functions */
 
 FILE *tectonic_get_file(const char *name)
 {
   const char *path = tectonic_get_file_path(name);
-  if (path)
-    return fopen(path, "rb");
-  else
-    return NULL;
+  return path ? fopen(path, "rb") : NULL;
 }
 
 void tectonic_record_version(FILE *fr)
@@ -547,12 +503,11 @@ void tectonic_record_version(FILE *fr)
     fwrite("!", 1, 1, fr);
     return;
   }
-
-  char buffer[4096];
-  int read;
-  while ((read = fread(buffer, 1, 4096, fh)) > 0)
+  char buffer[READ_HASH_SIZE];
+  ssize_t n;
+  while ((n = fread(buffer, 1, READ_HASH_SIZE, fh)) > 0)
   {
-    if (fwrite(buffer, 1, read, fr) != read)
+    if (fwrite(buffer, 1, n, fr) != (size_t)n)
       break;
   }
   fclose(fh);
@@ -566,14 +521,14 @@ bool tectonic_check_version(FILE *fr)
     char c;
     return (fread(&c, 1, 1, fr) == 1 && c == '!');
   }
-
-  char b1[4096], b2[4096];
-  int read, valid = 1;
-  while ((read = fread(b1, 1, 4096, fh)) > 0)
+  char b1[READ_HASH_SIZE], b2[READ_HASH_SIZE];
+  ssize_t n;
+  bool valid = true;
+  while ((n = fread(b1, 1, READ_HASH_SIZE, fh)) > 0)
   {
-    if ((fread(b2, 1, read, fr) == read) && (memcmp(b1, b2, read) == 0))
+    if ((fread(b2, 1, n, fr) == (size_t)n) && (memcmp(b1, b2, n) == 0))
       continue;
-    valid = 0;
+    valid = false;
     break;
   }
   valid = valid && (feof(fh) && !ferror(fh));
@@ -585,8 +540,7 @@ bool tectonic_has_file(const char *name)
 {
   list_tectonic_files();
   int index = lookup_entry_index(name);
-  int offset = entries[index];
-  return offset != -1;
+  return entries[index] != -1;
 }
 
 bool tectonic_available(void)

--- a/src/common/tectonic_provider.c
+++ b/src/common/tectonic_provider.c
@@ -9,24 +9,10 @@
 int *entries;
 int entries_pow = 1;
 
-char *names = NULL;
-size_t names_len = 0, names_cap = 1;
-
-static void append_buffer(char *buffer, int len)
-{
-  size_t new_len = names_len + len;
-  if (new_len > names_cap)
-  {
-    while (new_len > names_cap)
-      names_cap *= 2;
-    names = realloc(names, names_cap);
-    if (names == NULL)
-      do_abortf("Cannot allocate buffer to read Tectonic bundle");
-  }
-
-  memmove(names + names_len, buffer, len);
-  names_len += len;
-}
+char *tt_index = NULL;
+size_t tt_index_len = 0, tt_index_cap = 1;
+bool tt_index_skip = 0;
+bool tt_is_v15 = 0;
 
 static unsigned long sdbm_hash(const void *p)
 {
@@ -50,13 +36,286 @@ int lookup_entry_index(const char *name)
     int offset = entries[index];
     if (offset == -1)
       return index;
-    if (strcmp(name, names + offset) == 0)
+    if (strcmp(name, tt_index + offset) == 0)
       return index;
     index = (index + 1) & mask;
   }
 }
 
-static bool check_cache_validity(void)
+static const char *tectonic_user_cache_path(const char *suffixes[])
+{
+  static char dir[4096] = {0,}, *ptr = NULL;
+  static bool init = 0;
+
+  if (!init)
+  {
+    init = 1;
+
+    FILE *p = popen("tectonic -X show user-cache-dir", "r");
+
+    // Tectonic not found
+    if (!p)
+    {
+      fprintf(stderr, "tectonic: not found\n");
+      return 0;
+    }
+
+    size_t n = fread(dir, 1, sizeof(dir) - 1, p);
+
+    if (n > 0 && dir[n-1] == '\n')
+    {
+      n--;
+      dir[n] = 0;
+      ptr = dir + n;
+      fprintf(stderr, "tectonic: cache directory is %s\n", dir);
+    }
+    else
+      fprintf(stderr, "tectonic provider: malformed cache path: \"%s\"\n", dir);
+  }
+
+  if (!ptr)
+    return NULL;
+
+  if (suffixes)
+  {
+    char *p = ptr;
+    while (*suffixes)
+    {
+      p = stpcpy(p, *suffixes);
+      suffixes++;
+    }
+  }
+  return dir;
+}
+#define tectonic_user_cache_path(...) tectonic_user_cache_path((const char *[]){__VA_ARGS__ __VA_OPT__(,) NULL})
+
+/* Tectonic 0.16 support */
+
+char *tt_dirs = NULL;
+size_t tt_dirs_len = 0, tt_dirs_cap = 1;
+
+static void tt16_add_dir(char *name)
+{
+  size_t name_len = strlen(name) + 1;
+  size_t new_len = tt_dirs_len + name_len;
+  if (new_len >= tt_dirs_cap)
+  {
+    while (new_len >= tt_dirs_cap)
+      tt_dirs_cap *= 2;
+    tt_dirs = realloc(tt_dirs, tt_dirs_cap);
+    if (tt_dirs == NULL)
+      do_abortf("tectonic provider: cannot allocate buffer to store bundle directory");
+  }
+
+  memmove(tt_dirs + tt_dirs_len, name, name_len);
+  tt_dirs_len = new_len;
+}
+
+static void tt16_add_to_index(char *buffer, int len)
+{
+  size_t new_cap = tt_index_len + len;
+  if (new_cap >= tt_index_cap)
+  {
+    while (new_cap >= tt_index_cap)
+      tt_index_cap *= 2;
+    tt_index = realloc(tt_index, tt_index_cap);
+    if (tt_index == NULL)
+      do_abortf("tectonic provider: cannot allocate buffer to read bundle index");
+  }
+
+  for (int i = 0; i < len; i++)
+  {
+    if (tt_index_skip)
+    {
+      if (buffer[i] == '\n')
+        tt_index_skip = 0;
+    }
+    else
+    {
+      if (buffer[i] == ' ' || buffer[i] == '\n')
+      {
+        tt_index_skip = 1;
+        tt_index[tt_index_len++] = '\0';
+      }
+      else
+        tt_index[tt_index_len++] = buffer[i];
+    }
+  }
+}
+
+static void tt16_load_index_file(const char *path)
+{
+  FILE *f = fopen(path, "r");
+  if (!f)
+  {
+    fprintf(stderr, "tectonic provider: cannot read index file %s\n", path);
+    return;
+  }
+
+  bool skip = false;
+  char buffer[4096];
+  ssize_t read;
+
+  while ((read = fread(buffer, 1, 4096, f)) > 0)
+    tt16_add_to_index(buffer, read);
+
+  if (ferror(f))
+    perror("fread");
+
+  fclose(f);
+}
+
+static void tt16_load_indexes(void)
+{
+  const char *data_dir = tectonic_user_cache_path("/data/");
+  DIR *dirp = NULL;
+
+  if (!data_dir || !(dirp = opendir(data_dir)))
+    return;
+
+  // We found the data directory, load all .index files
+  struct dirent *entry;
+  const char *suffix = ".index";
+  size_t suffix_len = strlen(suffix);
+
+  while ((entry = readdir(dirp)) != NULL)
+  {
+    if (entry->d_type == DT_DIR)
+      tt16_add_dir(entry->d_name);
+    else if (entry->d_type == DT_REG)
+    {
+      size_t name_len = strlen(entry->d_name);
+      if (name_len >= suffix_len &&
+          strcmp(entry->d_name + (name_len - suffix_len), suffix) == 0)
+        tt16_load_index_file(tectonic_user_cache_path("/data/", entry->d_name));
+    }
+  }
+
+  closedir(dirp);
+}
+
+static bool tt16_list_tectonic_files(void)
+{
+  tt16_load_indexes();
+
+  if (tt_index_len == 0)
+  {
+    fprintf(stderr,
+            "Cannot find Tectonic bundle(s) manifests. Trying to initialize "
+            "tectonic now.\n");
+    system("tectonic -X bundle cat SHA256SUM");
+    tt16_load_indexes();
+  }
+  if (tt_index_len == 0)
+    return false;
+
+  // Count number of entries
+  int count = 0;
+  for (int i = 0; i < tt_index_len; i++)
+    if (tt_index[i] == '\0')
+      count += 1;
+
+  // Allocate hashtable for indexing lines
+  int min_cap = count * 4 / 3;
+  while ((1 << entries_pow) <= min_cap)
+    entries_pow++;
+  entries = malloc((1 << entries_pow) * sizeof(*entries));
+  if (entries == NULL)
+    do_abortf("Cannot allocate table for indexing Tectonic bundle.");
+  for (int i = 0; i < (1 << entries_pow); i++)
+    entries[i] = -1;
+
+  // Populate table
+  for (int i = 0, j = 0; j < tt_index_len; j++)
+  {
+    if (tt_index[j] != '\0')
+      continue;
+
+    if (i != j)
+    {
+      int index = lookup_entry_index(tt_index + i);
+      if (entries[index] == -1)
+        entries[index] = i;
+      else
+        fprintf(stderr, "tectonic bundle: duplicate entry (%s)\n",
+                tt_index + i);
+    }
+    i = j + 1;
+  }
+
+  fprintf(stderr, "tectonic bundle: indexing succeeded (%d entries)\n", count);
+  return true;
+}
+
+static const char *tt16_get_file_path(const char *name)
+{
+  for (const char *dir = tt_dirs; dir < tt_dirs + tt_dirs_len; dir = dir + strlen(dir) + 1)
+  {
+    const char *path = tectonic_user_cache_path("/data/", dir, "/", name);
+    if (access(path, R_OK) == 0)
+      return path;
+  }
+
+  fprintf(stderr, "tectonic provider: %s missing, trying to fetch with tectonic\n", name);
+
+  {
+    char command[1024] = ">/dev/null tectonic -X bundle cat ";
+    char *p = command;
+    const char *pname = name;
+
+    while (*p)
+      p++;
+
+    *p++ = '\'';
+    while (*pname)
+    {
+      if ((*p++ = *pname++) != '\'')
+        continue;
+      *p++ = '\\';
+      *p++ = '\'';
+      *p++ = '\'';
+    }
+    *p++ = '\'';
+    *p = '\0';
+
+    int retcode = system(command);
+    if (retcode != 0)
+      fprintf(stderr, "tectonic provider: \"%s\" returned code %d\n", command,
+              retcode);
+  }
+
+  for (const char *dir = tt_dirs; dir < tt_dirs + tt_dirs_len; dir = dir + strlen(dir) + 1)
+  {
+    const char *path = tectonic_user_cache_path("/data/", dir, "/", name);
+    if (access(path, R_OK) == 0)
+    {
+      fprintf(stderr, "tectonic provider: found %s\n", path);
+      return path;
+    }
+  }
+
+  do_abortf("tectonic provider: cannot load %s, skipping\n", name);
+  return NULL;
+}
+
+/* Tectonic old versions support */
+
+static void tt15_append_buffer(char *buffer, int len)
+{
+  size_t new_len = tt_index_len + len;
+  if (new_len > tt_index_cap)
+  {
+    while (new_len > tt_index_cap)
+      tt_index_cap *= 2;
+    tt_index = realloc(tt_index, tt_index_cap);
+    if (tt_index == NULL)
+      do_abortf("Cannot allocate buffer to read Tectonic bundle");
+  }
+  memmove(tt_index + tt_index_len, buffer, len);
+  tt_index_len += len;
+}
+
+static bool tt15_check_cache_validity(void)
 {
   const char *dir = cache_path("tectonic", "SHA256SUM");
 
@@ -90,9 +349,9 @@ static bool check_cache_validity(void)
   return (r1 == r2) && (memcmp(b1, b2, r1) == 0);
 }
 
-static void prepare_cache(void)
+static void tt15_prepare_cache(void)
 {
-  if (check_cache_validity())
+  if (tt15_check_cache_validity())
     return;
 
   // Base cache directory
@@ -123,13 +382,8 @@ static void prepare_cache(void)
   if (f) fclose(f);
 }
 
-static void list_tectonic_files(void)
+static bool tt15_list_tectonic_files(void)
 {
-  static int loaded = 0;
-  if (loaded)
-    return;
-  loaded = 1;
-
   // Read the list of all files
   FILE *f = popen("tectonic -X bundle search", "r");
   if (f == NULL)
@@ -138,21 +392,17 @@ static void list_tectonic_files(void)
   char buffer[4096];
   ssize_t read;
   while ((read = fread(buffer, 1, 4096, f)) > 0)
-  {
-    append_buffer(buffer, read);
-  }
+    tt15_append_buffer(buffer, read);
 
   if (ferror(f))
-  {
     perror("fread/popen");
-  }
 
   pclose(f);
 
   // Count number of lines
   int count = 0;
-  for (int i = 0; i < names_len; i++)
-    if (names[i] == '\n')
+  for (int i = 0; i < tt_index_len; i++)
+    if (tt_index[i] == '\n')
       count += 1;
 
   // Allocate hashtable for indexing lines
@@ -166,25 +416,27 @@ static void list_tectonic_files(void)
     entries[i] = -1;
 
   // Populate table
-  for (int i = 0, j = 0; j < names_len; j++)
+  for (int i = 0, j = 0; j < tt_index_len; j++)
   {
-    if (names[j] == '\n')
+    if (tt_index[j] == '\n')
     {
-      names[j] = '\0';
-      int index = lookup_entry_index(names + i);
+      tt_index[j] = '\0';
+      int index = lookup_entry_index(tt_index + i);
       if (entries[index] == -1)
         entries[index] = i;
       else
-        fprintf(stderr, "tectonic bundle: duplicate entry (%s)\n", names + i);
+        fprintf(stderr, "tectonic bundle: duplicate entry (%s)\n", tt_index + i);
       i = j + 1;
     }
   }
 
   fprintf(stderr, "tectonic bundle: indexing succeeded (%d entries)\n", count);
-  prepare_cache();
+  tt15_prepare_cache();
+
+  return tt_index_len > 0;
 }
 
-FILE *tectonic_cat(const char *name)
+static FILE *tt15_cat(const char *name)
 {
   if (!tectonic_has_file(name))
     return NULL;
@@ -207,14 +459,7 @@ FILE *tectonic_cat(const char *name)
   return popen(buffer, "r");
 }
 
-bool tectonic_has_file(const char *name)
-{
-  list_tectonic_files();
-  int index = lookup_entry_index(name);
-  return (entries[index] != -1);
-}
-
-const char *tectonic_get_file_path(const char *name)
+static const char *tt15_get_file_path(const char *name)
 {
   if (!tectonic_has_file(name))
     return NULL;
@@ -227,7 +472,7 @@ const char *tectonic_get_file_path(const char *name)
   if (!f)
     return NULL;
 
-  FILE *p = tectonic_cat(name);
+  FILE *p = tt15_cat(name);
   if (!p)
     return NULL;
 
@@ -238,18 +483,52 @@ const char *tectonic_get_file_path(const char *name)
     if (fwrite(buffer, 1, read, f) != read)
       break;
   }
-  if (read != 0 || ferror(p) || ferror(f))
+
+  bool error = read != 0 || ferror(p) || ferror(f);
+  pclose(p);
+  fclose(f);
+  if (error)
   {
-    pclose(p);
-    fclose(f);
     unlink(cached);
     return NULL;
   }
-  pclose(p);
-  fclose(f);
 
   return cached;
 }
+
+/* Version dispatch functions */
+
+const char *tectonic_get_file_path(const char *name)
+{
+  if (!tectonic_has_file(name))
+    return NULL;
+
+  return tt_is_v15 ? tt15_get_file_path(name) : tt16_get_file_path(name);
+}
+
+static void list_tectonic_files(void)
+{
+  static int loaded = 0;
+  if (loaded)
+    return;
+  loaded = 1;
+
+  if (tt16_list_tectonic_files())
+    return;
+
+  tt_is_v15 = 1;
+  if (tt15_list_tectonic_files())
+    return;
+
+  // No manifest... Tectonic was not initialized?
+  fprintf(stderr,
+          "Cannot find Tectonic bundle(s) manifests.\n"
+          "Please compile a document with tectonic before launching "
+          "TeXpresso.\n");
+  exit(1);
+}
+
+/* Generic functions */
 
 FILE *tectonic_get_file(const char *name)
 {
@@ -300,6 +579,14 @@ bool tectonic_check_version(FILE *fr)
   valid = valid && (feof(fh) && !ferror(fh));
   fclose(fh);
   return valid;
+}
+
+bool tectonic_has_file(const char *name)
+{
+  list_tectonic_files();
+  int index = lookup_entry_index(name);
+  int offset = entries[index];
+  return offset != -1;
 }
 
 bool tectonic_available(void)


### PR DESCRIPTION
This PR implements direct access to Tectonic cache (compatible with v0.16.9).
By accessing the cache directly, TeXpresso don't have to do its own caching and rely less on `tectonic -X bundle` commands which are quite slow and depend on internet access.

It's a tentative solution for #138.