### PR TITLE
fix: bound synctex-forward target page against page count

### DIFF
--- a/src/frontend/main.c
+++ b/src/frontend/main.c
@@ -1406,7 +1406,8 @@ bool texpresso_main(struct persistent_state *ps)
         fprintf(stderr, "[synctex forward] sync: hit page %d, coordinates (%d, %d)\n",
                 page, x, y);
 
-        if (page != ui->page)
+        if (page != ui->page &&
+            page >= 0 && page < send(page_count, ui->eng))
         {
           ui->page = page;
           display_page(ps, ui);


### PR DESCRIPTION
Forward-synctex assigned `ui->page` from `synctex_find_target` and called `display_page` without checking the target against the engine's page count. During incremental compilation (notably `-stream` mode), synctex can reference a page the incremental DVI has not produced yet, so `incdvi_page_dim` aborts on an out-of-range page.

Fix: skip the jump when the target page is out of range; a later synctex-forward retries once the DVI catches up.

Pre-existing since 475170ab2 (2023-08-26).